### PR TITLE
Add an EditorConfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,19 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{js,json,scss,css,html,svelte}]
+indent_size = 2
+
+[*.md]
+indent_style = tab
+
+[Makefile]
+indent_style = tab
+indent_size = 8


### PR DESCRIPTION
Add an [EditorConfig](https://editorconfig.org/) file to help maintain consistent use of space. There’s a VSCode plugin for EditorConfig support.