### PR TITLE
Setup GitHub Actions for the UI service

### DIFF
--- a/.github/workflows/ui-cleanup-pr-images.yaml
+++ b/.github/workflows/ui-cleanup-pr-images.yaml
@@ -1,0 +1,20 @@
+name: Cleanup PR images
+
+on:
+  pull_request:
+    types: [closed]
+    paths:
+      - '.nvmrc'
+      - 'services/ui/**'
+jobs:
+  purge-images:
+    name: Cleanup PR images from ghcr.io
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cleanup images
+        uses: bots-house/ghcr-delete-image-action@v1.0.1
+        with:
+          owner: noaa-gsl
+          name: unified-graphics/ui
+          token: ${{ secrets.GHCR_CLEANUP_PAT }}
+          tag: ${GITHUB_HEAD_REF}

--- a/.github/workflows/ui.yaml
+++ b/.github/workflows/ui.yaml
@@ -72,7 +72,6 @@ jobs:
       - uses: actions/checkout@v3
       - name: Extract branch/tag name
         shell: bash
-        # Note - this doesn't support branch names with "/" in them
         run: |
           if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
             # PR build
@@ -111,7 +110,6 @@ jobs:
     steps:
       - name: Extract branch/tag name
         shell: bash
-        # Note - this doesn't support branch names with "/" in them
         run: |
           if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
             # PR build
@@ -143,7 +141,6 @@ jobs:
         env:
           TRIVY_USERNAME: ${{ github.actor }}
           TRIVY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v2
         with:

--- a/.github/workflows/ui.yaml
+++ b/.github/workflows/ui.yaml
@@ -75,15 +75,15 @@ jobs:
         run: |
           if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
             # PR build
-            echo "BRANCH=${GITHUB_HEAD_REF}" >> $GITHUB_ENV
+            echo "BRANCH=${GITHUB_HEAD_REF}" >> ${GITHUB_ENV}
           elif [[ "${GITHUB_EVENT_NAME}" == "push" ]]; then
             # Handle differences between branches/tags
             if [[ "${GITHUB_REF}" == *"heads"* ]]; then
               # Branch build
-              echo "BRANCH=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
+              echo "BRANCH=${GITHUB_REF#refs/heads/}" >> ${GITHUB_ENV}
             elif [[ "${GITHUB_REF}" == *"tags"* ]]; then
               # Tag build
-              echo "BRANCH=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+              echo "BRANCH=${GITHUB_REF#refs/tags/}" >> ${GITHUB_ENV}
             else
               echo "ERROR: Unanticipated Git Ref"
               exit 1
@@ -113,15 +113,15 @@ jobs:
         run: |
           if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
             # PR build
-            echo "BRANCH=${GITHUB_HEAD_REF}" >> $GITHUB_ENV
+            echo "BRANCH=${GITHUB_HEAD_REF}" >> ${GITHUB_ENV}
           elif [[ "${GITHUB_EVENT_NAME}" == "push" ]]; then
             # Handle differences between branches/tags
             if [[ "${GITHUB_REF}" == *"heads"* ]]; then
               # Branch build
-              echo "BRANCH=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
+              echo "BRANCH=${GITHUB_REF#refs/heads/}" >> ${GITHUB_ENV}
             elif [[ "${GITHUB_REF}" == *"tags"* ]]; then
               # Tag build
-              echo "BRANCH=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+              echo "BRANCH=${GITHUB_REF#refs/tags/}" >> ${GITHUB_ENV}
             else
               echo "ERROR: Unanticipated Git Ref"
               exit 1

--- a/.github/workflows/ui.yaml
+++ b/.github/workflows/ui.yaml
@@ -64,7 +64,7 @@ jobs:
         working-directory: services/ui
         run: |
           npx playwright install-deps
-          npm run test
+          npm test
   build:
     runs-on: ubuntu-latest
     needs: [lint, check, test]

--- a/.github/workflows/ui.yaml
+++ b/.github/workflows/ui.yaml
@@ -1,0 +1,150 @@
+name: "UI Build"
+on:
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
+      - '[0-9]+.[0-9]+.[0-9]+-rc[0-9]+'
+    branches: [ $default-branch ]
+    # Path filters aren't evaluated for tags - https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore
+    paths:
+      - '.nvmrc'
+      - 'services/ui/**'
+  pull_request:
+    paths:
+      - '.nvmrc'
+      - 'services/ui/**'
+    branches: [ $default-branch ]
+env:
+  REGISTRY: ghcr.io/noaa-gsl/unified-graphics/ui
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+          cache-dependency-path: 'services/ui/package-lock.json'
+      - name: Install dependencies
+        working-directory: services/ui
+        run: npm ci
+      - name: Lint
+        working-directory: services/ui
+        run: npm run lint
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+          cache-dependency-path: 'services/ui/package-lock.json'
+      - name: Install dependencies
+        working-directory: services/ui
+        run: npm ci
+      - name: Check
+        working-directory: services/ui
+        run: npm run check
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+          cache-dependency-path: 'services/ui/package-lock.json'
+      - name: Install dependencies
+        working-directory: services/ui
+        run: npm ci
+      - name: Test
+        working-directory: services/ui
+        run: |
+          npx playwright install-deps
+          npm run test
+  build:
+    runs-on: ubuntu-latest
+    needs: [lint, check, test]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Extract branch/tag name
+        shell: bash
+        # Note - this doesn't support branch names with "/" in them
+        run: |
+          if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
+            # PR build
+            echo "BRANCH=${GITHUB_HEAD_REF}" >> $GITHUB_ENV
+          elif [[ "${GITHUB_EVENT_NAME}" == "push" ]]; then
+            # Handle differences between branches/tags
+            if [[ "${GITHUB_REF}" == *"heads"* ]]; then
+              # Branch build
+              echo "BRANCH=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
+            elif [[ "${GITHUB_REF}" == *"tags"* ]]; then
+              # Tag build
+              echo "BRANCH=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+            else
+              echo "ERROR: Unanticipated Git Ref"
+              exit 1
+            fi
+          else
+            echo "ERROR: Unanticipated GitHub Event"
+            exit 1
+          fi
+      - name: Build & tag image
+        run: |
+          docker build -t ${{ env.REGISTRY }}:${{ env.BRANCH }} services/ui
+      - name: Login to GHCR
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Push image
+        run: |
+          docker push ${{ env.REGISTRY }}:${{ env.BRANCH }}
+  scan:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Extract branch/tag name
+        shell: bash
+        # Note - this doesn't support branch names with "/" in them
+        run: |
+          if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
+            # PR build
+            echo "BRANCH=${GITHUB_HEAD_REF}" >> $GITHUB_ENV
+          elif [[ "${GITHUB_EVENT_NAME}" == "push" ]]; then
+            # Handle differences between branches/tags
+            if [[ "${GITHUB_REF}" == *"heads"* ]]; then
+              # Branch build
+              echo "BRANCH=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
+            elif [[ "${GITHUB_REF}" == *"tags"* ]]; then
+              # Tag build
+              echo "BRANCH=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+            else
+              echo "ERROR: Unanticipated Git Ref"
+              exit 1
+            fi
+          else
+            echo "ERROR: Unanticipated GitHub Event"
+            exit 1
+          fi
+      - name: Scan image with Trivy
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: '${{ env.REGISTRY }}:${{ env.BRANCH }}'
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+          ignore-unfixed: true
+          severity: 'CRITICAL,HIGH'
+        env:
+          TRIVY_USERNAME: ${{ github.actor }}
+          TRIVY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: 'trivy-results.sarif'

--- a/services/ui/playwright.config.js
+++ b/services/ui/playwright.config.js
@@ -4,6 +4,7 @@ const config = {
     command: "npm run build && npm run preview",
     port: 3000,
   },
+  reporter: process.env.CI ? 'github' : 'list',
 };
 
 export default config;


### PR DESCRIPTION
Set up GitHub actions for the UI service.

# Overview

This PR adds two workflows:
1. To lint, check, test, build and scan the UI service using the npm scripts in `package.json`
2. To clean up PR images for closed PRs

The first workflow will build PR images for preview deployments as well as images for the main branch and for tags like `x.y.z` or `x.y.z-rc#`. It will also use Trivy to scan for critical & high vulnerabilities in the container image and upload them for viewing in GitHub's Security tab.

# Todo
- [x] Lint the code with `npm run lint`
- [x] Lint the code with `npm run check`
- [x] Test the code with `npm run test`
- [x] Build the application with docker and push to GHCR
- [x] Scan the docker image with Trivy & upload the results to GitHub's security tab
- [x] Clean up old PR images when the PR is closed