### PR TITLE
Setup GitHub Actions for the API service

### DIFF
--- a/.github/workflows/api-cleanup-pr-images.yaml
+++ b/.github/workflows/api-cleanup-pr-images.yaml
@@ -1,0 +1,19 @@
+name: Cleanup PR images
+
+on:
+  pull_request:
+    types: [closed]
+    paths:
+      - 'services/api/**'
+jobs:
+  purge-images:
+    name: Cleanup PR images from ghcr.io
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cleanup images
+        uses: bots-house/ghcr-delete-image-action@v1.0.1
+        with:
+          owner: noaa-gsl
+          name: unified-graphics/api
+          token: ${{ secrets.GHCR_CLEANUP_PAT }}
+          tag: ${GITHUB_HEAD_REF}

--- a/.github/workflows/api.yaml
+++ b/.github/workflows/api.yaml
@@ -80,15 +80,15 @@ jobs:
         run: |
           if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
             # PR build
-            echo "BRANCH=${GITHUB_HEAD_REF}" >> $GITHUB_ENV
+            echo "BRANCH=${GITHUB_HEAD_REF}" >> ${GITHUB_ENV}
           elif [[ "${GITHUB_EVENT_NAME}" == "push" ]]; then
             # Handle differences between branches/tags
             if [[ "${GITHUB_REF}" == *"heads"* ]]; then
               # Branch build
-              echo "BRANCH=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
+              echo "BRANCH=${GITHUB_REF#refs/heads/}" >> ${GITHUB_ENV}
             elif [[ "${GITHUB_REF}" == *"tags"* ]]; then
               # Tag build
-              echo "BRANCH=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+              echo "BRANCH=${GITHUB_REF#refs/tags/}" >> ${GITHUB_ENV}
             else
               echo "ERROR: Unanticipated Git Ref"
               exit 1
@@ -118,15 +118,15 @@ jobs:
         run: |
           if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
             # PR build
-            echo "BRANCH=${GITHUB_HEAD_REF}" >> $GITHUB_ENV
+            echo "BRANCH=${GITHUB_HEAD_REF}" >> ${GITHUB_ENV}
           elif [[ "${GITHUB_EVENT_NAME}" == "push" ]]; then
             # Handle differences between branches/tags
             if [[ "${GITHUB_REF}" == *"heads"* ]]; then
               # Branch build
-              echo "BRANCH=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
+              echo "BRANCH=${GITHUB_REF#refs/heads/}" >> ${GITHUB_ENV}
             elif [[ "${GITHUB_REF}" == *"tags"* ]]; then
               # Tag build
-              echo "BRANCH=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+              echo "BRANCH=${GITHUB_REF#refs/tags/}" >> ${GITHUB_ENV}
             else
               echo "ERROR: Unanticipated Git Ref"
               exit 1

--- a/.github/workflows/api.yaml
+++ b/.github/workflows/api.yaml
@@ -1,0 +1,152 @@
+name: "API Service Build"
+on:
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
+      - '[0-9]+.[0-9]+.[0-9]+-rc[0-9]+'
+    branches: [ $default-branch ]
+    # Path filters aren't evaluated for tags - https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore
+    paths:
+      - 'services/api/**'
+  pull_request:
+    paths:
+      - 'services/api/**'
+    branches: [ $default-branch ]
+env:
+  REGISTRY: ghcr.io/noaa-gsl/unified-graphics/api
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install poetry
+        run: pipx install poetry
+      - uses: actions/setup-python@v3
+        with:
+          python-version: '3.9'
+          cache: 'poetry'
+          cache-dependency-path: 'services/api/poetry.lock'
+      - name: Install dependencies
+        working-directory: services/api
+        run: poetry install
+      - name: Lint with Black
+        working-directory: services/api
+        run: poetry run black --check .
+      - name: Lint with Flake8
+        working-directory: services/api
+        run: poetry run flake8 --count --show-source --statistics .
+  type-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install poetry
+        run: pipx install poetry
+      - uses: actions/setup-python@v3
+        with:
+          python-version: '3.9'
+          cache: 'poetry'
+          cache-dependency-path: 'services/api/poetry.lock'
+      - name: Install dependencies
+        working-directory: services/api
+        run: poetry install
+      - name: Check Types with mypy
+        working-directory: services/api
+        run: poetry run mypy src/
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install poetry
+        run: pipx install poetry
+      - uses: actions/setup-python@v3
+        with:
+          python-version: '3.9'
+          cache: 'poetry'
+          cache-dependency-path: 'services/api/poetry.lock'
+      - name: Install dependencies
+        working-directory: services/api
+        run: poetry install
+      - name: Test
+        working-directory: services/api
+        run: poetry run pytest
+  build:
+    runs-on: ubuntu-latest
+    needs: [lint, type-check, test]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Extract branch/tag name
+        shell: bash
+        run: |
+          if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
+            # PR build
+            echo "BRANCH=${GITHUB_HEAD_REF}" >> $GITHUB_ENV
+          elif [[ "${GITHUB_EVENT_NAME}" == "push" ]]; then
+            # Handle differences between branches/tags
+            if [[ "${GITHUB_REF}" == *"heads"* ]]; then
+              # Branch build
+              echo "BRANCH=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
+            elif [[ "${GITHUB_REF}" == *"tags"* ]]; then
+              # Tag build
+              echo "BRANCH=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+            else
+              echo "ERROR: Unanticipated Git Ref"
+              exit 1
+            fi
+          else
+            echo "ERROR: Unanticipated GitHub Event"
+            exit 1
+          fi
+      - name: Build & tag image
+        run: |
+          docker build -t ${{ env.REGISTRY }}:${{ env.BRANCH }} services/api
+      - name: Login to GHCR
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Push image
+        run: |
+          docker push ${{ env.REGISTRY }}:${{ env.BRANCH }}
+  scan:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Extract branch/tag name
+        shell: bash
+        run: |
+          if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
+            # PR build
+            echo "BRANCH=${GITHUB_HEAD_REF}" >> $GITHUB_ENV
+          elif [[ "${GITHUB_EVENT_NAME}" == "push" ]]; then
+            # Handle differences between branches/tags
+            if [[ "${GITHUB_REF}" == *"heads"* ]]; then
+              # Branch build
+              echo "BRANCH=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
+            elif [[ "${GITHUB_REF}" == *"tags"* ]]; then
+              # Tag build
+              echo "BRANCH=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+            else
+              echo "ERROR: Unanticipated Git Ref"
+              exit 1
+            fi
+          else
+            echo "ERROR: Unanticipated GitHub Event"
+            exit 1
+          fi
+      - name: Scan image with Trivy
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: '${{ env.REGISTRY }}:${{ env.BRANCH }}'
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+          ignore-unfixed: true
+          severity: 'CRITICAL,HIGH'
+        env:
+          TRIVY_USERNAME: ${{ github.actor }}
+          TRIVY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: 'trivy-results.sarif'


### PR DESCRIPTION
Set up GitHub Actions for the API service

# Overview
Add two workflows:
1. To lint, type-check, test, build and scan the API service
2. To clean up PR images for closed PRs

The first workflow will build PR images for preview deployments as well
as images for the main branch and for tags like `x.y.z` or `x.y.z-rc#`.
It will also use Trivy to scan for critical & high vulnerabilities in
the container image and upload them for viewing in GitHub's Security
tab.

# Todo

- [x] Lint the code with `poetry run flake8` && `poetry run black`
- [x] Type check the code with `poetry run mypy`
- [x] Test the code with `poetry run pytest`
- [x] Build the application with docker and push to GHCR
- [x] Scan the docker image with Trivy & upload the results to GitHub's security tab
- [x] Clean up old PR images when the PR is closed