### PR TITLE
Fix issues found in first CI run

### DIFF
--- a/.github/workflows/api.yaml
+++ b/.github/workflows/api.yaml
@@ -96,6 +96,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
+      - uses: actions/checkout@v3
       - name: Extract branch/tag name
         run: python3 ./.github/scripts/extract_git_ref.py # Provides env.BRANCH
       - name: Scan image with Trivy

--- a/.github/workflows/ui.yaml
+++ b/.github/workflows/ui.yaml
@@ -67,6 +67,7 @@ jobs:
         working-directory: services/ui
         run: |
           npx playwright install-deps
+          npx playwright install
           npm test
   build:
     runs-on: ubuntu-latest
@@ -91,6 +92,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
+      - uses: actions/checkout@v3
       - name: Extract branch/tag name
         run: python3 ./.github/scripts/extract_git_ref.py # Provides env.BRANCH
       - name: Scan image with Trivy

--- a/services/ui/playwright.config.js
+++ b/services/ui/playwright.config.js
@@ -4,7 +4,7 @@ const config = {
     command: "npm run build && npm run preview",
     port: 3000,
   },
-  reporter: process.env.CI ? 'github' : 'list',
+  reporter: process.env.CI ? "github" : "list",
 };
 
 export default config;


### PR DESCRIPTION
The first CI run revealed:

- The `extract_git_ref.py` script wasn't available to the Scan job
- Playwright was being installed incorrectly for the UI tests
- `playwright.config.js` needed to be linted.