### PR TITLE
Configure CI to deploy to ECR

### DIFF
--- a/.github/workflows/api.yaml
+++ b/.github/workflows/api.yaml
@@ -114,3 +114,31 @@ jobs:
         uses: github/codeql-action/upload-sarif@v2
         with:
           sarif_file: 'trivy-results.sarif'
+  deploy:
+    runs-on: ubuntu-latest
+    environment: vlab
+    concurrency: vlab
+    needs: scan
+    steps:
+      - uses: actions/checkout@v3
+      - name: Extract branch/tag name
+        run: python3 ./.github/scripts/extract_git_ref.py # Provides env.BRANCH
+      - name: Login to GHCR
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+      - name: Login to ECR
+        uses: aws-actions/amazon-ecr-login@v1
+      - name: retag image and push
+        run: |
+          docker pull ${{ env.REGISTRY }}:${{ env.BRANCH }}
+          docker tag ${{ env.REGISTRY }}:${{ env.BRANCH }} ${{ secrets.AWS_REGISTRY }}/api:${{ env.BRANCH }}
+          docker push ${{ secrets.AWS_REGISTRY }}/api:${{ env.BRANCH }}

--- a/.github/workflows/api.yaml
+++ b/.github/workflows/api.yaml
@@ -4,7 +4,7 @@ on:
     tags:
       - '[0-9]+.[0-9]+.[0-9]+'
       - '[0-9]+.[0-9]+.[0-9]+-rc[0-9]+'
-    branches: [ $default-branch ]
+    branches: [ main ]
     # Path filters aren't evaluated for tags - https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore
     paths:
       - 'services/api/**'
@@ -13,7 +13,7 @@ on:
     paths:
       - 'services/api/**'
       - '.github/workflows/**'
-    branches: [ $default-branch ]
+    branches: [ main ]
   workflow_dispatch: # Manually
 env:
   REGISTRY: ghcr.io/noaa-gsl/unified-graphics/api

--- a/.github/workflows/check-ci.yaml
+++ b/.github/workflows/check-ci.yaml
@@ -2,11 +2,11 @@ name: Check CI scripts
 
 on:
   pull_request:
-    branches: [ $default-branch ]
+    branches: [ main ]
     paths:
       - '.github/scripts/**'
   push:
-    branches: [ $default-branch ]
+    branches: [ main ]
     paths:
       - '.github/scripts/**'
 

--- a/.github/workflows/ui.yaml
+++ b/.github/workflows/ui.yaml
@@ -4,7 +4,7 @@ on:
     tags:
       - '[0-9]+.[0-9]+.[0-9]+'
       - '[0-9]+.[0-9]+.[0-9]+-rc[0-9]+'
-    branches: [ $default-branch ]
+    branches: [ main ]
     # Path filters aren't evaluated for tags - https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore
     paths:
       - '.nvmrc'
@@ -15,7 +15,7 @@ on:
       - '.nvmrc'
       - 'services/ui/**'
       - '.github/workflows/**'
-    branches: [ $default-branch ]
+    branches: [ main ]
   workflow_dispatch: # Manually
 env:
   REGISTRY: ghcr.io/noaa-gsl/unified-graphics/ui

--- a/.github/workflows/ui.yaml
+++ b/.github/workflows/ui.yaml
@@ -110,3 +110,31 @@ jobs:
         uses: github/codeql-action/upload-sarif@v2
         with:
           sarif_file: 'trivy-results.sarif'
+  deploy:
+    runs-on: ubuntu-latest
+    environment: vlab
+    concurrency: vlab
+    needs: scan
+    steps:
+      - uses: actions/checkout@v3
+      - name: Extract branch/tag name
+        run: python3 ./.github/scripts/extract_git_ref.py # Provides env.BRANCH
+      - name: Login to GHCR
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+      - name: Login to ECR
+        uses: aws-actions/amazon-ecr-login@v1
+      - name: retag image and push
+        run: |
+          docker pull ${{ env.REGISTRY }}:${{ env.BRANCH }}
+          docker tag ${{ env.REGISTRY }}:${{ env.BRANCH }} ${{ secrets.AWS_REGISTRY }}/ui:${{ env.BRANCH }}
+          docker push ${{ secrets.AWS_REGISTRY }}/ui:${{ env.BRANCH }}


### PR DESCRIPTION
This change sets up GitHub Actions to pull the new image tag from GHCR, retag it, and push it to the AWS ECR registry specified in the `vlab` environment