### PR TITLE
Block the deploy job if Trivy finds vulnerabilties

### DIFF
--- a/.github/workflows/api.yaml
+++ b/.github/workflows/api.yaml
@@ -107,10 +107,12 @@ jobs:
           output: 'trivy-results.sarif'
           ignore-unfixed: true
           severity: 'CRITICAL,HIGH'
+          exit-code: '1'
         env:
           TRIVY_USERNAME: ${{ github.actor }}
           TRIVY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload Trivy scan results to GitHub Security tab
+        if: always()
         uses: github/codeql-action/upload-sarif@v2
         with:
           sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/ui.yaml
+++ b/.github/workflows/ui.yaml
@@ -103,10 +103,12 @@ jobs:
           output: 'trivy-results.sarif'
           ignore-unfixed: true
           severity: 'CRITICAL,HIGH'
+          exit-code: '1'
         env:
           TRIVY_USERNAME: ${{ github.actor }}
           TRIVY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload Trivy scan results to GitHub Security tab
+        if: always()
         uses: github/codeql-action/upload-sarif@v2
         with:
           sarif_file: 'trivy-results.sarif'


### PR DESCRIPTION
However, make sure that the scan results are always uploaded to GitHub's Security tab.