### PR TITLE
Cleanup ECR Images

### DIFF
--- a/.github/workflows/api-cleanup-pr-images.yaml
+++ b/.github/workflows/api-cleanup-pr-images.yaml
@@ -6,7 +6,7 @@ on:
     paths:
       - 'services/api/**'
 jobs:
-  purge-images:
+  purge-ghcr-images:
     name: Cleanup PR images from ghcr.io
     runs-on: ubuntu-latest
     steps:
@@ -17,3 +17,20 @@ jobs:
           name: unified-graphics/api
           token: ${{ secrets.GHCR_CLEANUP_PAT }}
           tag: ${GITHUB_HEAD_REF}
+  purge-ecr-images:
+    name: Cleanup PR images from ECR
+    runs-on: ubuntu-latest
+    environment: vlab
+    concurrency: vlab
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+      - name: Cleanup image
+        run: |
+          aws ecr batch-delete-image \
+            --repository-name rtma-viz/api \
+            --image-ids imageTag=${GITHUB_HEAD_REF}

--- a/.github/workflows/api-cleanup-pr-images.yaml
+++ b/.github/workflows/api-cleanup-pr-images.yaml
@@ -5,6 +5,8 @@ on:
     types: [closed]
     paths:
       - 'services/api/**'
+      - '.github/workflows/**'
+      - '.github/scripts/**'
 jobs:
   purge-ghcr-images:
     name: Cleanup PR images from ghcr.io

--- a/.github/workflows/api.yaml
+++ b/.github/workflows/api.yaml
@@ -9,10 +9,12 @@ on:
     paths:
       - 'services/api/**'
       - '.github/workflows/**'
+      - '.github/scripts/**'
   pull_request:
     paths:
       - 'services/api/**'
       - '.github/workflows/**'
+      - '.github/scripts/**'
     branches: [ main ]
   workflow_dispatch: # Manually
 env:

--- a/.github/workflows/ui-cleanup-pr-images.yaml
+++ b/.github/workflows/ui-cleanup-pr-images.yaml
@@ -7,7 +7,7 @@ on:
       - '.nvmrc'
       - 'services/ui/**'
 jobs:
-  purge-images:
+  purge-ghcr-images:
     name: Cleanup PR images from ghcr.io
     runs-on: ubuntu-latest
     steps:
@@ -18,3 +18,20 @@ jobs:
           name: unified-graphics/ui
           token: ${{ secrets.GHCR_CLEANUP_PAT }}
           tag: ${GITHUB_HEAD_REF}
+  purge-ecr-images:
+    name: Cleanup PR images from ECR
+    runs-on: ubuntu-latest
+    environment: vlab
+    concurrency: vlab
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+      - name: Cleanup image
+        run: |
+          aws ecr batch-delete-image \
+            --repository-name rtma-viz/ui \
+            --image-ids imageTag=${GITHUB_HEAD_REF}

--- a/.github/workflows/ui-cleanup-pr-images.yaml
+++ b/.github/workflows/ui-cleanup-pr-images.yaml
@@ -6,6 +6,8 @@ on:
     paths:
       - '.nvmrc'
       - 'services/ui/**'
+      - '.github/workflows/**'
+      - '.github/scripts/**'
 jobs:
   purge-ghcr-images:
     name: Cleanup PR images from ghcr.io

--- a/.github/workflows/ui.yaml
+++ b/.github/workflows/ui.yaml
@@ -10,11 +10,13 @@ on:
       - '.nvmrc'
       - 'services/ui/**'
       - '.github/workflows/**'
+      - '.github/scripts/**'
   pull_request:
     paths:
       - '.nvmrc'
       - 'services/ui/**'
       - '.github/workflows/**'
+      - '.github/scripts/**'
     branches: [ main ]
   workflow_dispatch: # Manually
 env:


### PR DESCRIPTION
This PR adds jobs to clean up our PR images in the ECR repository when they're cleaned up in GHCR. 

Since we aren't prefixing our PR image tags with a common string it's difficult to manage them separately from the `main` tag (which we do want to persist) using AWS lifecycle policies. This seemed like the easiest way to go.