### PR TITLE
Fix PR image cleanup in Actions

### DIFF
--- a/.github/workflows/api-cleanup-pr-images.yaml
+++ b/.github/workflows/api-cleanup-pr-images.yaml
@@ -18,7 +18,7 @@ jobs:
           owner: noaa-gsl
           name: unified-graphics/api
           token: ${{ secrets.GHCR_CLEANUP_PAT }}
-          tag: ${GITHUB_HEAD_REF}
+          tag: ${{ github.head_ref }}
   purge-ecr-images:
     name: Cleanup PR images from ECR
     runs-on: ubuntu-latest
@@ -35,4 +35,4 @@ jobs:
         run: |
           aws ecr batch-delete-image \
             --repository-name rtma-vis/api \
-            --image-ids imageTag=${GITHUB_HEAD_REF}
+            --image-ids imageTag=${{ github.head_ref }}

--- a/.github/workflows/ui-cleanup-pr-images.yaml
+++ b/.github/workflows/ui-cleanup-pr-images.yaml
@@ -19,7 +19,7 @@ jobs:
           owner: noaa-gsl
           name: unified-graphics/ui
           token: ${{ secrets.GHCR_CLEANUP_PAT }}
-          tag: ${GITHUB_HEAD_REF}
+          tag: ${{ github.head_ref }}
   purge-ecr-images:
     name: Cleanup PR images from ECR
     runs-on: ubuntu-latest
@@ -36,4 +36,4 @@ jobs:
         run: |
           aws ecr batch-delete-image \
             --repository-name rtma-vis/ui \
-            --image-ids imageTag=${GITHUB_HEAD_REF}
+            --image-ids imageTag=${{ github.head_ref }}


### PR DESCRIPTION
It appears that environment variables aren't valid in GitHub Action "with:" statements. Switch to using the same variable but from the `github` context - which is available in the `jobs.<job_id>.steps.with.<with_id>` workflow key.

See: https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability