### PR TITLE
Disable stylelint for Svelte files

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -58,8 +58,8 @@ check_web() {
       git show ":$1" \
         | ./node_modules/.bin/eslint "--stdin" "--stdin-filename" "$1" > /dev/null 2>&1 \
         || err "[eslint   ]: $1 failed linting"
-      ;;&
-    css|scss|svelte)
+      ;;
+    css|scss)
       git show ":$1" \
         | ./node_modules/.bin/stylelint "--stdin" "--stdin-filename" "$1" > /dev/null 2>&1 \
         || err "[stylelint]: $1 failed linting"

--- a/services/ui/package.json
+++ b/services/ui/package.json
@@ -10,8 +10,8 @@
     "check": "svelte-check --tsconfig ./jsconfig.json",
     "check:watch": "svelte-check --tsconfig ./jsconfig.json --watch",
     "test": "playwright test",
-    "lint": "prettier --ignore-path .gitignore --check --plugin-search-dir=. . && eslint --ignore-path .gitignore . && stylelint --ignore-path .gitignore **/*.{css,scss,svelte}",
-    "format": "prettier --ignore-path .gitignore --write --plugin-search-dir=. . && stylelint --ignore-path .gitignore --fix **/*.{css,scss,svelte}"
+    "lint": "prettier --ignore-path .gitignore --check --plugin-search-dir=. . && eslint --ignore-path .gitignore . && stylelint --ignore-path .gitignore src/**/*.{css,scss}",
+    "format": "prettier --ignore-path .gitignore --write --plugin-search-dir=. . && stylelint --ignore-path .gitignore --fix src/**/*.{css,scss}"
   },
   "devDependencies": {
     "@playwright/test": "^1.21.0",


### PR DESCRIPTION
For some reason, stylelint is hanging on some of our Svelte components.
I'm disabling it for now to avoid getting hung up on fixing dev tools
when we have a demo coming up in less than a week.
