### PR TITLE
Rename diag_temperature route function to diagnostics

### DIFF
--- a/services/api/src/unified_graphics/routes.py
+++ b/services/api/src/unified_graphics/routes.py
@@ -23,7 +23,7 @@ def index():
 
 
 @bp.route("/diag/<variable>/")
-def diag_temperature(variable):
+def diagnostics(variable):
     if not hasattr(diag, variable):
         return jsonify(msg=f"Variable not found: '{variable}'"), 404
 


### PR DESCRIPTION
The route is not temperature-specific anymore, so we should use a more
generic name for the function.

This should have been part of the temperature refactor, but I didn't
notice the function name until after I merged. This is why we like code
reviews.
