### PR TITLE
Increase timeouts for large requests

### DIFF
--- a/services/api/Dockerfile
+++ b/services/api/Dockerfile
@@ -13,4 +13,4 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 EXPOSE 80
-CMD ["gunicorn", "unified_graphics.wsgi:app", "--bind=0.0.0.0:80"]
+CMD ["gunicorn", "unified_graphics.wsgi:app", "--bind=0.0.0.0:80", "--timeout=600"]

--- a/services/ui/default.conf.template
+++ b/services/ui/default.conf.template
@@ -6,6 +6,10 @@ server {
 
     location /api/ {
         proxy_pass ${UG_DIAG_API_HOST};
+        # Make the client IP available to the API server for better tracing/debugging
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        # The API service can take a long time to return for vector data
+        proxy_read_timeout 600s;
     }
 
     location / {


### PR DESCRIPTION
The vectorized wind data is large, increase timeouts in gunicorn and in
Nginx from the defaults (30 seconds and 60 seconds, respectively) to 600
seconds.