### PR TITLE
Fix vector variable diagnostic display

### DIFF
--- a/services/ui/src/js/components/Chart/Chart2DHistogram.js
+++ b/services/ui/src/js/components/Chart/Chart2DHistogram.js
@@ -17,6 +17,17 @@ export default class Chart2DHistogram extends ChartElement {
     return ChartElement.observedAttributes;
   }
 
+  // If we don't override this here, Svelte ends up setting a data attribute on
+  // the web component instead of using the property, which means no data gets
+  // displayed.
+  get data() {
+    return super.data;
+  }
+
+  set data(value) {
+    super.data = value;
+  }
+
   render() {
     const svg = select(this.shadowRoot).select("svg");
     const { height, width } = svg.node().parentElement.getBoundingClientRect();

--- a/services/ui/src/js/components/DiagnosticView/DiagnosticView.svelte
+++ b/services/ui/src/js/components/DiagnosticView/DiagnosticView.svelte
@@ -8,6 +8,7 @@
 
   let currentVariable = null;
   let selection = null;
+  let variableType = "scalar";
 
   $: variables = fetch("/api/diag/")
     .then((response) => response.json())
@@ -25,6 +26,12 @@
   $: filtered = featureCollection.then((data) =>
     data.features.filter(geoFilter(selection))
   );
+
+  $: {
+    featureCollection.then((data) => {
+      variableType = data.features[0].properties.type;
+    });
+  }
 </script>
 
 <select class="usa-select" bind:value={currentVariable}>
@@ -38,10 +45,16 @@
 {#await filtered}
   <p>Loading</p>
 {:then data}
-  <LoopDisplay {data} loop="guess" {selection} on:chart-brush={onBrush}>
+  <LoopDisplay {data} loop="guess" {variableType} {selection} on:chart-brush={onBrush}>
     <h2 slot="title" class="font-ui-lg text-bold grid-col-full">Guess</h2>
   </LoopDisplay>
-  <LoopDisplay {data} loop="analysis" {selection} on:chart-brush={onBrush}>
+  <LoopDisplay
+    {data}
+    loop="analysis"
+    {variableType}
+    {selection}
+    on:chart-brush={onBrush}
+  >
     <h2 slot="title" class="font-ui-lg text-bold grid-col-full">Analysis</h2>
   </LoopDisplay>
 {/await}


### PR DESCRIPTION
The diagnostic display for vector variables was empty. This PR fixes that bug, although brushing on the map is still broken for both scalars and vectors.
