### PR TITLE
Fix chart rendering when variable type changes

### DIFF
--- a/services/ui/src/js/components/ChartContainer/ChartContainer.js
+++ b/services/ui/src/js/components/ChartContainer/ChartContainer.js
@@ -78,7 +78,7 @@ export default class ChartContainer extends HTMLElement {
       this.#resized();
     });
 
-    this.#mutationObserver.observe(this.#container, {
+    this.#mutationObserver.observe(this, {
       childList: true,
       attributes: false,
       subtree: false,
@@ -87,7 +87,7 @@ export default class ChartContainer extends HTMLElement {
 
   disconnectedCallback() {
     this.#resizeObserver.unobserve(this.#container);
-    this.#mutationObserver.disconnect(this.#container);
+    this.#mutationObserver.disconnect(this);
   }
 
   #resized() {


### PR DESCRIPTION
With the new design for displaying the loading icon, we stopped destroying and recreating our charts on every variable selection. We only create new charts if the element type actually changes. But our mutation observer wasn’t configured correctly, so when we swapped out the histogram for the heatmap, the heatmap never got dimensions because the chart-container didn’t notice. Therefore, the distributions stopped rendering.
