### PR TITLE
Use a quantized color scale for the bubble map

### DIFF
--- a/services/ui/src/js/components/Chart2DHistogram/Chart2DHistogram.js
+++ b/services/ui/src/js/components/Chart2DHistogram/Chart2DHistogram.js
@@ -129,6 +129,14 @@ export default class Chart2DHistogram extends ChartElement {
 
   set data(value) {
     this.#data = value;
+
+    // FIXME: This is duplicated across all charts to ensure that they fire
+    // this event. This event is used by the ColorRamp component so that it
+    // knows when to update itself and could be useful for other chart
+    // interactions.
+    const event = new CustomEvent("chart-datachanged", { bubbles: true });
+    this.dispatchEvent(event);
+
     this.update();
   }
 

--- a/services/ui/src/js/components/ChartHistogram/ChartHistogram.js
+++ b/services/ui/src/js/components/ChartHistogram/ChartHistogram.js
@@ -145,6 +145,14 @@ class ChartHistogram extends ChartElement {
     this.#deviation = deviation(value);
 
     this.#data = value;
+
+    // FIXME: This is duplicated across all charts to ensure that they fire
+    // this event. This event is used by the ColorRamp component so that it
+    // knows when to update itself and could be useful for other chart
+    // interactions.
+    const event = new CustomEvent("chart-datachanged", { bubbles: true });
+    this.dispatchEvent(event);
+
     this.update();
   }
 

--- a/services/ui/src/js/components/ChartMap/ChartMap.js
+++ b/services/ui/src/js/components/ChartMap/ChartMap.js
@@ -110,6 +110,14 @@ export default class ChartMap extends ChartElement {
 
   set data(value) {
     this.#data = value;
+
+    // FIXME: This is duplicated across all charts to ensure that they fire
+    // this event. This event is used by the ColorRamp component so that it
+    // knows when to update itself and could be useful for other chart
+    // interactions.
+    const event = new CustomEvent("chart-datachanged", { bubbles: true });
+    this.dispatchEvent(event);
+
     this.update();
   }
 

--- a/services/ui/src/js/components/ColorRamp/ColorRamp.js
+++ b/services/ui/src/js/components/ColorRamp/ColorRamp.js
@@ -66,6 +66,14 @@ export default class ColorRamp extends HTMLElement {
     root.innerHTML = `<style>${ColorRamp.#STYLE}</style>${ColorRamp.#TEMPLATE}`;
   }
 
+  connectedCallback() {
+    document.addEventListener("chart-datachanged", this.onDataChanged);
+  }
+
+  disconnectedCallback() {
+    document.removeEventListener("chart-datachanged", this.onDataChanged);
+  }
+
   get for() {
     return this.getAttribute("for");
   }
@@ -93,6 +101,14 @@ export default class ColorRamp extends HTMLElement {
 
     this.update();
   }
+
+  /**
+   * Re-render when the data changes on the chart this legend is for.
+   */
+  onDataChanged = (event) => {
+    if (event.target.id !== this.for) return;
+    this.update();
+  };
 
   /**
    * Schedule an update to the component

--- a/services/ui/src/js/components/DiagnosticView/DiagnosticView.svelte
+++ b/services/ui/src/js/components/DiagnosticView/DiagnosticView.svelte
@@ -3,6 +3,7 @@
   import LoopDisplay from "./LoopDisplay.svelte";
 
   let currentVariable = null;
+  let variableName = "";
   let variableType = "scalar";
   let variableData = { features: [] };
 
@@ -25,6 +26,17 @@
   $: featureCollection = currentVariable
     ? fetch(`/api${currentVariable}`).then((response) => response.json())
     : new Promise(() => {});
+
+  $: {
+    if (currentVariable) {
+      variables.then((data) => {
+        variableName = data.reduce((name, variable) => {
+          if (variable.url === currentVariable) return variable.name;
+          return name;
+        }, "");
+      });
+    }
+  }
 
   $: {
     featureCollection.then((data) => {
@@ -50,10 +62,10 @@ observations side-by-side for both the guess and analysis loops.
 
 <div class="container flex-1" data-layout="stack">
   <div class="scroll-container flex-1" data-layout="stack">
-    <LoopDisplay data={variableData} loop="guess" {variableType}>
+    <LoopDisplay data={variableData} loop="guess" {variableType} {variableName}>
       <h2 slot="title" class="font-ui-lg text-bold grid-col-full">Guess</h2>
     </LoopDisplay>
-    <LoopDisplay data={variableData} loop="analysis" {variableType}>
+    <LoopDisplay data={variableData} loop="analysis" {variableType} {variableName}>
       <h2 slot="title" class="font-ui-lg text-bold grid-col-full">Analysis</h2>
     </LoopDisplay>
   </div>

--- a/services/ui/src/js/components/DiagnosticView/LoopDisplay.svelte
+++ b/services/ui/src/js/components/DiagnosticView/LoopDisplay.svelte
@@ -121,10 +121,14 @@ Usage:
   </chart-container>
   <chart-container>
     <chart-map
+      id="observations-{loop}"
       data={mapData}
       selection={$region}
       radius={mapRadius}
       on:chart-brush={onBrushMap}
     />
+    <color-ramp slot="legend" for="observations-{loop}" class="font-ui-3xs" format="s"
+      >Value</color-ramp
+    >
   </chart-container>
 </div>

--- a/services/ui/src/js/components/DiagnosticView/LoopDisplay.svelte
+++ b/services/ui/src/js/components/DiagnosticView/LoopDisplay.svelte
@@ -22,6 +22,11 @@
   export let variableType = "scalar";
 
   /**
+   * The name of the variable on display.
+   */
+  export let variableName = "";
+
+  /**
    * Handle range selection on histograms.
    *
    * @param {CustomEvent} event
@@ -81,6 +86,8 @@
     variableType === "vector"
       ? (d) => d.properties[loop].magnitude
       : (d) => d.properties[loop];
+
+  $: mapLegendTitle = variableName === "wind" ? `${variableName} speed` : variableName;
 </script>
 
 <!--
@@ -128,7 +135,7 @@ Usage:
       on:chart-brush={onBrushMap}
     />
     <color-ramp slot="legend" for="observations-{loop}" class="font-ui-3xs" format="s"
-      >Value</color-ramp
+      >{mapLegendTitle}</color-ramp
     >
   </chart-container>
 </div>


### PR DESCRIPTION
Convert the color scale for the map from a continuous scale to a quantized one.
I think the binned values will be easier to read off of the map. I also fixed
the issue with the legend for the map always being titled "speed" (#124).

