### PR TITLE
Reset the selections when any selection is changed

### DIFF
--- a/services/ui/src/js/components/DiagnosticView/LoopDisplay.svelte
+++ b/services/ui/src/js/components/DiagnosticView/LoopDisplay.svelte
@@ -33,6 +33,10 @@
    */
   const onBrushHistogram = (event) => {
     event.stopImmediatePropagation();
+    region.set([
+      [0, 0],
+      [0, 0],
+    ]);
     range.set(event.detail);
   };
 
@@ -41,6 +45,7 @@
    */
   const onBrushMap = (event) => {
     event.stopImmediatePropagation();
+    range.set([0, 0]);
     region.set(event.detail);
   };
 


### PR DESCRIPTION
This prevents multiple selections — one on the map and one on the
histogram — from being applied simultaneously, which creates kind of a
weird state where the data shown on the histogram includes more data
than is included on the map.
