### PR TITLE
Format histogram annotations

### DIFF
--- a/services/ui/src/js/components/ChartHistogram/ChartHistogram.js
+++ b/services/ui/src/js/components/ChartHistogram/ChartHistogram.js
@@ -71,6 +71,11 @@ class ChartHistogram extends ChartElement {
 
   .annotation line {
     stroke: currentColor;
+  }
+
+  .annotation text {
+    font-weight: bold;
+    text-shadow: 1px 1px 1px white;
   }`;
 
   /** @type {?number[]} **/

--- a/services/ui/src/js/components/ChartHistogram/ChartHistogram.js
+++ b/services/ui/src/js/components/ChartHistogram/ChartHistogram.js
@@ -315,6 +315,10 @@ class ChartHistogram extends ChartElement {
       .attr("width", (d) => xScale(d.x1) - xScale(d.x0))
       .attr("height", (d) => yScale(0) - yScale(d.length));
 
+    // Left-align the annotations if the mean of the distribution is to the
+    // left of center in the chart, otherwise we'll right-align the text.
+    const leftAligned = xScale(this.mean) <= width / 2;
+
     const annotation = svg
       .select(".annotation")
       .attr("transform", `translate(${margin.left}, ${margin.top})`);
@@ -329,6 +333,17 @@ class ChartHistogram extends ChartElement {
         const y = fontSize * 3;
         const width =
           xScale(this.mean + this.deviation) - xScale(this.mean - this.deviation);
+        let x1 = width;
+        let x2 = width + 0.75 * fontSize;
+        let x = width + fontSize;
+        let anchor = "start";
+
+        if (!leftAligned) {
+          x1 = 0;
+          x2 = -0.75 * fontSize;
+          x = -fontSize;
+          anchor = "end";
+        }
 
         g.selectAll("rect")
           .data([null])
@@ -339,17 +354,18 @@ class ChartHistogram extends ChartElement {
         g.selectAll("line")
           .data([null])
           .join("line")
-          .attr("x1", width)
+          .attr("x1", x1)
           .attr("y1", y)
-          .attr("x2", width + 0.75 * fontSize)
+          .attr("x2", x2)
           .attr("y2", y);
 
         g.selectAll("text")
           .data([null])
           .join("text")
-          .attr("x", width + fontSize)
+          .attr("x", x)
           .attr("y", y)
           .attr("dominant-baseline", "middle")
+          .attr("text-anchor", anchor)
           .text(`σ = ${fmt(this.deviation)}`);
       });
 
@@ -360,6 +376,13 @@ class ChartHistogram extends ChartElement {
       .attr("transform", `translate(${xScale(this.mean)},0)`)
       .call((g) => {
         const fmt = xAxis.tickFormat();
+        let x = fontSize * 0.25;
+        let anchor = "start";
+
+        if (!leftAligned) {
+          x *= -1;
+          anchor = "end";
+        }
 
         g.selectAll("line")
           .data([null])
@@ -370,8 +393,9 @@ class ChartHistogram extends ChartElement {
           .data([null])
           .join("text")
           .attr("dominant-baseline", "middle")
-          .attr("x", fontSize * 0.25)
+          .attr("x", x)
           .attr("y", fontSize * 1.5)
+          .attr("text-anchor", anchor)
           .text(`mean = ${fmt(this.mean)}`);
       });
 

--- a/services/ui/src/js/components/ChartHistogram/ChartHistogram.js
+++ b/services/ui/src/js/components/ChartHistogram/ChartHistogram.js
@@ -326,26 +326,29 @@ class ChartHistogram extends ChartElement {
       .attr("transform", `translate(${xScale(this.mean - this.deviation)},1)`)
       .call((g) => {
         const fmt = xAxis.tickFormat();
+        const y = fontSize * 3;
+        const width =
+          xScale(this.mean + this.deviation) - xScale(this.mean - this.deviation);
 
         g.selectAll("rect")
           .data([null])
           .join("rect")
-          .attr(
-            "width",
-            xScale(this.mean + this.deviation) - xScale(this.mean - this.deviation)
-          )
+          .attr("width", width)
           .attr("height", height - margin.top - margin.bottom);
 
         g.selectAll("line")
           .data([null])
           .join("line")
-          .attr("x2", -0.75 * fontSize);
+          .attr("x1", width)
+          .attr("y1", y)
+          .attr("x2", width + 0.75 * fontSize)
+          .attr("y2", y);
 
         g.selectAll("text")
           .data([null])
           .join("text")
-          .attr("x", -fontSize)
-          .attr("text-anchor", "end")
+          .attr("x", width + fontSize)
+          .attr("y", y)
           .attr("dominant-baseline", "middle")
           .text(`σ = ${fmt(this.deviation)}`);
       });
@@ -368,6 +371,7 @@ class ChartHistogram extends ChartElement {
           .join("text")
           .attr("dominant-baseline", "middle")
           .attr("x", fontSize * 0.25)
+          .attr("y", fontSize * 1.5)
           .text(`mean = ${fmt(this.mean)}`);
       });
 

--- a/services/ui/src/js/components/DiagnosticView/LoopDisplay.svelte
+++ b/services/ui/src/js/components/DiagnosticView/LoopDisplay.svelte
@@ -122,6 +122,7 @@ Usage:
       id="distribution-{loop}"
       data={distributionData}
       selection={$range}
+      format-x=".3e"
       on:chart-brush={onBrushHistogram}
     />
     <span class="axis-x title" slot="title-x">{xTitle}</span>


### PR DESCRIPTION
Fix the formatting for the annotations on the histograms. Reposition the
annotations so that they don't overlap with the observation count in the chart
and so that they are less likely to be clipped by the edges of the chart. The
labels have been made bold and given a slight text shadow to increase contrast
against the background, but more work will likely be needed to improve
legibility.
