### PR TITLE
Change vector variable distributions to u v coordinates

### DIFF
--- a/services/api/src/unified_graphics/diag.py
+++ b/services/api/src/unified_graphics/diag.py
@@ -232,3 +232,37 @@ def wind() -> List[Observation]:
         )
         for idx, stationId in enumerate(ges["Station_ID"].values)
     ]
+
+
+def wind_magnitude() -> List[Observation]:
+    ges = open_diagnostic(Variable.WIND, MinimLoop.GUESS)
+    anl = open_diagnostic(Variable.WIND, MinimLoop.ANALYSIS)
+
+    ges_forecast_u = ges["u_Observation"] - ges["u_Obs_Minus_Forecast_adjusted"]
+    ges_forecast_v = ges["v_Observation"] - ges["v_Obs_Minus_Forecast_adjusted"]
+
+    anl_forecast_u = anl["u_Observation"] - anl["u_Obs_Minus_Forecast_adjusted"]
+    anl_forecast_v = anl["v_Observation"] - anl["v_Obs_Minus_Forecast_adjusted"]
+
+    ges_forecast_mag = vector.magnitude(ges_forecast_u.values, ges_forecast_v.values)
+    anl_forecast_mag = vector.magnitude(anl_forecast_u.values, anl_forecast_v.values)
+    obs_mag = vector.magnitude(ges["u_Observation"].values, ges["v_Observation"].values)
+
+    ges_mag = obs_mag - ges_forecast_mag
+    anl_mag = obs_mag - anl_forecast_mag
+
+    return [
+        Observation(
+            stationId.decode("utf-8").strip(),
+            "wind",
+            VariableType.SCALAR,
+            guess=round(float(ges_mag[idx]), 5),
+            analysis=round(float(anl_mag[idx]), 5),
+            observed=round(float(obs_mag[idx]), 5),
+            position=Coordinate(
+                round(float(ges["Longitude"].values[idx] - 360), 5),
+                round(float(ges["Latitude"].values[idx]), 5),
+            ),
+        )
+        for idx, stationId in enumerate(ges["Station_ID"].values)
+    ]

--- a/services/api/src/unified_graphics/routes.py
+++ b/services/api/src/unified_graphics/routes.py
@@ -40,3 +40,22 @@ def diagnostics(variable):
     )
 
     return response
+
+
+@bp.route("/diag/<variable>/<transform>/")
+def transform(variable, transform):
+    func = f"{variable}_{transform}"
+    if not hasattr(diag, func):
+        return (
+            jsonify(msg=f"'{transform}' is not available for variable '{variable}'"),
+            404,
+        )
+
+    variable_diagnostics = getattr(diag, func)
+    data = variable_diagnostics()
+
+    response = jsonify(
+        {"type": "FeatureCollection", "features": [obs.to_geojson() for obs in data]}
+    )
+
+    return response

--- a/services/api/src/unified_graphics/vector.py
+++ b/services/api/src/unified_graphics/vector.py
@@ -1,0 +1,23 @@
+import numpy as np
+
+
+def direction(u, v):
+    direction = (90 - np.degrees(np.arctan2(-v, -u))) % 360
+
+    # Anywhere the magnitude of the vector is 0
+    calm = (np.abs(u) == 0) & (np.abs(v) == 0)
+
+    # numpy.arctan2 treats 0.0 and -0.0 differently. Whenever the second
+    # argument to the function is -0.0, it return pi or -pi depending on the
+    # sign of the first argument. Whenever the second argument is 0.0, it will
+    # return 0.0 or -0.0 depending on the sign of the first argument. We
+    # normalize all calm vectors (magnitude 0) to have a direction of 0.0, per
+    # the NCAR Command Language docs.
+    # http://ncl.ucar.edu/Document/Functions/Contributed/wind_direction.shtml
+    direction[calm] = 0.0
+
+    return direction
+
+
+def magnitude(u, v):
+    return np.sqrt(u**2 + v**2)

--- a/services/api/tests/test_diag.py
+++ b/services/api/tests/test_diag.py
@@ -2,7 +2,6 @@ import os
 import time
 from pathlib import Path
 
-import numpy as np
 import pytest
 import requests
 import xarray as xr
@@ -256,37 +255,3 @@ def test_open_diagnostic_s3(
         result = diag.open_diagnostic(variable, loop)
 
     xr.testing.assert_equal(result, expected)
-
-
-# Test cases taken from the examples at
-# http://ncl.ucar.edu/Document/Functions/Contributed/wind_direction.shtml
-@pytest.mark.parametrize(
-    "u,v,expected",
-    (
-        [
-            np.array([10, 0, 0, -10, 10, 10, -10, -10]),
-            np.array([0, 10, -10, 0, 10, -10, 10, -10]),
-            np.array([270, 180, 0, 90, 225, 315, 135, 45]),
-        ],
-        [
-            np.array([0.0, -0.0, 0.0, -0.0]),
-            np.array([0.0, 0.0, -0.0, -0.0]),
-            np.array([0.0, 0.0, 0.0, 0.0]),
-        ],
-    ),
-)
-def test_vector_direction(u, v, expected):
-    result = diag.vector_direction(u, v)
-
-    np.testing.assert_array_almost_equal(result, expected, decimal=5)
-
-
-def test_vector_magnitude():
-    u = np.array([1, 0, 1, 0])
-    v = np.array([0, 1, 1, 0])
-
-    result = diag.vector_magnitude(u, v)
-
-    np.testing.assert_array_almost_equal(
-        result, np.array([1, 1, 1.41421, 0]), decimal=5
-    )

--- a/services/api/tests/test_unified_graphics.py
+++ b/services/api/tests/test_unified_graphics.py
@@ -164,7 +164,7 @@ def test_vector_magnitude(vector_data, client):
                 "type": "Feature",
                 "properties": {
                     "stationId": "WV270",
-                    "type": "vector",
+                    "type": "scalar",
                     "variable": "wind",
                     "guess": 0.5,
                     "analysis": -0.41421,
@@ -176,7 +176,7 @@ def test_vector_magnitude(vector_data, client):
                 "type": "Feature",
                 "properties": {
                     "stationId": "E4294",
-                    "type": "vector",
+                    "type": "scalar",
                     "variable": "wind",
                     "guess": -1.0,
                     "analysis": 0.0,
@@ -220,3 +220,13 @@ def test_unknown_variable(client):
 
     assert response.status_code == 404
     assert response.json == {"msg": "Variable not found: 'not_a_variable'"}
+
+
+@pytest.mark.parametrize("variable_name", ["temperature", "moisture", "pressure"])
+def test_unknown_transform(variable_name, client):
+    response = client.get(f"/diag/{variable_name}/magnitude/")
+
+    assert response.status_code == 404
+    assert response.json == {
+        "msg": f"'magnitude' is not available for variable '{variable_name}'"
+    }

--- a/services/api/tests/test_unified_graphics.py
+++ b/services/api/tests/test_unified_graphics.py
@@ -118,7 +118,7 @@ def test_scalar_diag(variable_name, variable_code, diag_file, client):
     }
 
 
-def test_wind_diag(vector_data, client):
+def test_vector_diag(vector_data, client):
     response = client.get("/diag/wind/")
 
     assert response.status_code == 200
@@ -131,9 +131,9 @@ def test_wind_diag(vector_data, client):
                     "stationId": "WV270",
                     "type": "vector",
                     "variable": "wind",
-                    "guess": {"magnitude": 0.5, "direction": 0.0},
-                    "analysis": {"magnitude": -0.41421, "direction": 45.0},
-                    "observed": {"magnitude": 1.0, "direction": 270.0},
+                    "guess": {"u": 0.5, "v": 0},
+                    "analysis": {"u": 0, "v": -1},
+                    "observed": {"u": 1, "v": 0},
                 },
                 "geometry": {"type": "Point", "coordinates": [-120.0, 40.0]},
             },
@@ -143,9 +143,9 @@ def test_wind_diag(vector_data, client):
                     "stationId": "E4294",
                     "type": "vector",
                     "variable": "wind",
-                    "guess": {"magnitude": -1.0, "direction": -90.0},
-                    "analysis": {"magnitude": 0.0, "direction": -90.0},
-                    "observed": {"magnitude": 1.0, "direction": 180.0},
+                    "guess": {"u": -2, "v": 1},
+                    "analysis": {"u": -1, "v": 1},
+                    "observed": {"u": 0, "v": 1},
                 },
                 "geometry": {"type": "Point", "coordinates": [-88.0, 30.0]},
             },

--- a/services/api/tests/test_vector.py
+++ b/services/api/tests/test_vector.py
@@ -1,0 +1,38 @@
+import numpy as np
+import pytest
+
+from unified_graphics import vector
+
+
+# Test cases taken from the examples at
+# http://ncl.ucar.edu/Document/Functions/Contributed/wind_direction.shtml
+@pytest.mark.parametrize(
+    "u,v,expected",
+    (
+        [
+            np.array([10, 0, 0, -10, 10, 10, -10, -10]),
+            np.array([0, 10, -10, 0, 10, -10, 10, -10]),
+            np.array([270, 180, 0, 90, 225, 315, 135, 45]),
+        ],
+        [
+            np.array([0.0, -0.0, 0.0, -0.0]),
+            np.array([0.0, 0.0, -0.0, -0.0]),
+            np.array([0.0, 0.0, 0.0, 0.0]),
+        ],
+    ),
+)
+def test_vector_direction(u, v, expected):
+    result = vector.direction(u, v)
+
+    np.testing.assert_array_almost_equal(result, expected, decimal=5)
+
+
+def test_vector_magnitude():
+    u = np.array([1, 0, 1, 0])
+    v = np.array([0, 1, 1, 0])
+
+    result = vector.magnitude(u, v)
+
+    np.testing.assert_array_almost_equal(
+        result, np.array([1, 1, 1.41421, 0]), decimal=5
+    )

--- a/services/ui/src/js/components/Chart2DHistogram/Chart2DHistogram.js
+++ b/services/ui/src/js/components/Chart2DHistogram/Chart2DHistogram.js
@@ -16,9 +16,8 @@ import { bin2d } from "../../helpers";
 
 /**
  * @typedef {object} DiagVector
- * @property {number} direction
- *   A value between 0 and 360 representing the orientation of the vector.
- * @property {number} magnitude The length of the vector.
+ * @property {number} u
+ * @property {number} v
  */
 
 /**
@@ -107,8 +106,8 @@ export default class Chart2DHistogram extends ChartElement {
       this.xScale.ticks(Math.floor(this.contentWidth / 10)),
       this.yScale.ticks(Math.floor(this.contentHeight / 10))
     )
-      .x((d) => d.direction)
-      .y((d) => d.magnitude);
+      .x((d) => d.u)
+      .y((d) => d.v);
 
     return binner(this.#data);
   }
@@ -144,7 +143,7 @@ export default class Chart2DHistogram extends ChartElement {
   // so that we can create multiple charts with the same axes.
   get domain() {
     if (!this.#data) return [0, 0];
-    return extent(this.#data, (d) => d.direction);
+    return extent(this.#data, (d) => d.v);
   }
 
   get formatX() {
@@ -175,7 +174,7 @@ export default class Chart2DHistogram extends ChartElement {
   // so that we can create multiple charts with the same axes.
   get range() {
     if (!this.#data) return [0, 0];
-    return extent(this.#data, (d) => d.magnitude);
+    return extent(this.#data, (d) => d.u);
   }
 
   get margin() {

--- a/services/ui/src/js/components/Chart2DHistogram/Chart2DHistogram.js
+++ b/services/ui/src/js/components/Chart2DHistogram/Chart2DHistogram.js
@@ -245,9 +245,17 @@ export default class Chart2DHistogram extends ChartElement {
 
     this.#brush();
 
+    const [[x0, y0], [x1, y1]] = this.#selection;
+
     const brush = new CustomEvent("chart-brush", {
       bubbles: true,
-      detail: this.selection,
+      detail:
+        x0 === x1 || y0 === y1
+          ? null
+          : [
+              [x0, y0],
+              [x1, y1],
+            ],
     });
     this.dispatchEvent(brush);
   };

--- a/services/ui/src/js/components/Chart2DHistogram/Chart2DHistogram.js
+++ b/services/ui/src/js/components/Chart2DHistogram/Chart2DHistogram.js
@@ -76,7 +76,10 @@ export default class Chart2DHistogram extends ChartElement {
   /** @type {DiagVector[]} */
   #data = [];
 
-  #selection = null;
+  #selection = [
+    [0, 0],
+    [0, 0],
+  ];
 
   #xScale = scaleLinear();
   #yScale = scaleLinear();
@@ -143,7 +146,7 @@ export default class Chart2DHistogram extends ChartElement {
   // so that we can create multiple charts with the same axes.
   get domain() {
     if (!this.#data) return [0, 0];
-    return extent(this.#data, (d) => d.v);
+    return extent(this.#data, (d) => d.u);
   }
 
   get formatX() {
@@ -174,7 +177,7 @@ export default class Chart2DHistogram extends ChartElement {
   // so that we can create multiple charts with the same axes.
   get range() {
     if (!this.#data) return [0, 0];
-    return extent(this.#data, (d) => d.u);
+    return extent(this.#data, (d) => d.v);
   }
 
   get margin() {
@@ -214,8 +217,8 @@ export default class Chart2DHistogram extends ChartElement {
 
   onMouseDown = ({ currentTarget, offsetX, offsetY }) => {
     const { left, top } = this.margin;
-    const x = this.#xScale.invert(offsetX - left);
-    const y = this.#yScale.invert(offsetY - top);
+    const x = this.xScale.invert(offsetX - left);
+    const y = this.yScale.invert(offsetY - top);
 
     this.#selection = [
       [x, y],
@@ -230,8 +233,8 @@ export default class Chart2DHistogram extends ChartElement {
     const { left, top } = this.margin;
 
     this.#selection[1] = [
-      this.#xScale.invert(offsetX - left),
-      this.#yScale.invert(offsetY - top),
+      this.xScale.invert(offsetX - left),
+      this.yScale.invert(offsetY - top),
     ];
 
     this.#brush();
@@ -250,7 +253,10 @@ export default class Chart2DHistogram extends ChartElement {
       bubbles: true,
       detail:
         x0 === x1 || y0 === y1
-          ? null
+          ? [
+              [0, 0],
+              [0, 0],
+            ]
           : [
               [x0, y0],
               [x1, y1],
@@ -330,11 +336,14 @@ export default class Chart2DHistogram extends ChartElement {
   }
 
   #brush() {
-    if (this.#selection === null) return;
+    let x0, y0, x1, y1;
+    x0 = y0 = x1 = y1 = 0;
 
-    const [x0, y0, x1, y1] = this.#selection
-      .flat()
-      .map((val, idx) => (idx % 2 === 0 ? this.#xScale(val) : this.#yScale(val)));
+    if (Array.isArray(this.#selection) && Array.isArray(this.#selection[0])) {
+      [x0, y0, x1, y1] = this.#selection
+        .flat()
+        .map((val, idx) => (idx % 2 === 0 ? this.xScale(val) : this.yScale(val)));
+    }
 
     select(this.shadowRoot.querySelector("svg"))
       .select("#selection")

--- a/services/ui/src/js/components/ChartHistogram/ChartHistogram.js
+++ b/services/ui/src/js/components/ChartHistogram/ChartHistogram.js
@@ -193,7 +193,6 @@ class ChartHistogram extends ChartElement {
   }
 
   set selection(value) {
-    console.log(value);
     this.#selection = structuredClone(value);
     this.#brush();
   }
@@ -265,7 +264,7 @@ class ChartHistogram extends ChartElement {
 
     const brush = new CustomEvent("chart-brush", {
       bubbles: true,
-      detail: lower === upper ? null : [lower, upper],
+      detail: lower === upper ? [0, 0] : [lower, upper],
     });
     this.dispatchEvent(brush);
   };

--- a/services/ui/src/js/components/ChartHistogram/ChartHistogram.js
+++ b/services/ui/src/js/components/ChartHistogram/ChartHistogram.js
@@ -261,9 +261,11 @@ class ChartHistogram extends ChartElement {
     // visible despite having updated the actual range.
     this.#selection.call(this.#brush);
 
+    const [lower, upper] = this.#selection.datum();
+
     const brush = new CustomEvent("chart-brush", {
       bubbles: true,
-      detail: structuredClone(this.#selection.datum()),
+      detail: lower === upper ? null : [lower, upper],
     });
     this.dispatchEvent(brush);
   };

--- a/services/ui/src/js/components/ChartMap/ChartMap.js
+++ b/services/ui/src/js/components/ChartMap/ChartMap.js
@@ -249,7 +249,6 @@ export default class ChartMap extends ChartElement {
     const [[x0, y0], [x1, y1]] = this.#selection;
 
     if (x0 === x1 || y0 === y1) {
-      this.#selection = null;
       this.#brush();
     }
 
@@ -294,6 +293,9 @@ export default class ChartMap extends ChartElement {
     if (!this.#selection) return;
 
     const [[x0, y0], [x1, y1]] = this.#selection;
+
+    if (x0 === x1 || y0 === y1) return;
+
     let left, right, top, bottom;
 
     if (x0 < x1) {

--- a/services/ui/src/js/components/DiagnosticView/DiagnosticView.stores.js
+++ b/services/ui/src/js/components/DiagnosticView/DiagnosticView.stores.js
@@ -1,5 +1,5 @@
 import { writable } from "svelte/store";
 
 export const region = writable(null);
-export const range = writable(null);
+export const range = writable([0, 0]);
 export const filteredObservations = writable(new Set());

--- a/services/ui/src/js/components/DiagnosticView/DiagnosticView.stores.js
+++ b/services/ui/src/js/components/DiagnosticView/DiagnosticView.stores.js
@@ -2,3 +2,4 @@ import { writable } from "svelte/store";
 
 export const region = writable(null);
 export const range = writable(null);
+export const filteredObservations = writable(new Set());

--- a/services/ui/src/js/components/DiagnosticView/DiagnosticView.stores.js
+++ b/services/ui/src/js/components/DiagnosticView/DiagnosticView.stores.js
@@ -1,5 +1,8 @@
 import { writable } from "svelte/store";
 
-export const region = writable(null);
+export const region = writable([
+  [0, 0],
+  [0, 0],
+]);
 export const range = writable([0, 0]);
 export const filteredObservations = writable(new Set());

--- a/services/ui/src/js/components/DiagnosticView/DiagnosticView.svelte
+++ b/services/ui/src/js/components/DiagnosticView/DiagnosticView.svelte
@@ -5,7 +5,8 @@
   let currentVariable = null;
   let variableName = "";
   let variableType = "scalar";
-  let variableData = { features: [] };
+  let distribution = { features: [] };
+  let observations = { features: [] };
 
   $: {
     // Clear the filters when currentVariable changes
@@ -38,12 +39,18 @@
     }
   }
 
-  $: {
-    featureCollection.then((data) => {
-      variableType = data.features[0].properties.type;
-      variableData = data;
-    });
-  }
+  $: featureCollection.then(async (data) => {
+    variableType = data.features[0].properties.type;
+    distribution = data;
+
+    if (variableType === "scalar") {
+      observations = data;
+    } else {
+      observations = await fetch(`/api${currentVariable}/magnitude/`).then((response) =>
+        response.json()
+      );
+    }
+  });
 </script>
 
 <!--
@@ -62,10 +69,22 @@ observations side-by-side for both the guess and analysis loops.
 
 <div class="container flex-1" data-layout="stack">
   <div class="scroll-container flex-1" data-layout="stack">
-    <LoopDisplay data={variableData} loop="guess" {variableType} {variableName}>
+    <LoopDisplay
+      {distribution}
+      {observations}
+      loop="guess"
+      {variableType}
+      {variableName}
+    >
       <h2 slot="title" class="font-ui-lg text-bold grid-col-full">Guess</h2>
     </LoopDisplay>
-    <LoopDisplay data={variableData} loop="analysis" {variableType} {variableName}>
+    <LoopDisplay
+      {distribution}
+      {observations}
+      loop="analysis"
+      {variableType}
+      {variableName}
+    >
       <h2 slot="title" class="font-ui-lg text-bold grid-col-full">Analysis</h2>
     </LoopDisplay>
   </div>

--- a/services/ui/src/js/components/DiagnosticView/DiagnosticView.svelte
+++ b/services/ui/src/js/components/DiagnosticView/DiagnosticView.svelte
@@ -11,8 +11,11 @@
   $: {
     // Clear the filters when currentVariable changes
     currentVariable;
-    range.set(null);
-    region.set(null);
+    range.set([0, 0]);
+    region.set([
+      [0, 0],
+      [0, 0],
+    ]);
   }
 
   $: variables = fetch("/api/diag/")

--- a/services/ui/src/js/components/DiagnosticView/LoopDisplay.svelte
+++ b/services/ui/src/js/components/DiagnosticView/LoopDisplay.svelte
@@ -101,14 +101,10 @@
     .map((d) => d.properties[loop]);
 
   $: xTitle =
-    variableType === "vector"
-      ? "Direction (Observation − Forecast)"
-      : "Observation − Forecast";
+    variableType === "vector" ? "u (Observation − Forecast)" : "Observation − Forecast";
 
   $: yTitle =
-    variableType === "vector"
-      ? "Magnitude (Observation − Forecast)"
-      : "Observation count";
+    variableType === "vector" ? "v (Observation − Forecast)" : "Observation count";
 
   $: mapData = {
     type: "FeatureCollection",

--- a/services/ui/src/js/components/DiagnosticView/LoopDisplay.svelte
+++ b/services/ui/src/js/components/DiagnosticView/LoopDisplay.svelte
@@ -99,10 +99,7 @@
     ),
   };
 
-  $: mapRadius =
-    variableType === "vector"
-      ? (d) => d.properties[loop].magnitude
-      : (d) => d.properties[loop];
+  $: mapRadius = (d) => d.properties[loop];
 
   $: mapLegendTitle = variableName === "wind" ? `${variableName} speed` : variableName;
 </script>

--- a/services/ui/src/js/components/DiagnosticView/LoopDisplay.svelte
+++ b/services/ui/src/js/components/DiagnosticView/LoopDisplay.svelte
@@ -36,6 +36,10 @@
     event.stopImmediatePropagation();
 
     range.set(event.detail);
+    region.set([
+      [0, 0],
+      [0, 0],
+    ]);
 
     if (event.detail === null) {
       filteredObservations.set(new Set());
@@ -56,8 +60,13 @@
     event.stopImmediatePropagation();
 
     region.set(event.detail);
+    range.set([0, 0]);
 
-    if (event.detail === null || event.detail[0] === event.detail[1]) {
+    if (
+      event.detail === null ||
+      event.detail[0][0] === event.detail[1][0] ||
+      event.detail[0][1] === event.detail[1][1]
+    ) {
       filteredObservations.set(new Set());
       return;
     }

--- a/services/ui/src/js/components/DiagnosticView/LoopDisplay.svelte
+++ b/services/ui/src/js/components/DiagnosticView/LoopDisplay.svelte
@@ -35,6 +35,17 @@
   const onBrushHistogram = (event) => {
     event.stopImmediatePropagation();
 
+    let distRange = event.detail;
+
+    if (variableType === "vector") {
+      let [[x0, y0], [x1, y1]] = event.detail;
+
+      distRange = {
+        u: [x0, x1].sort(),
+        v: [y0, y1].sort(),
+      };
+    }
+
     range.set(event.detail);
     region.set([
       [0, 0],
@@ -47,7 +58,7 @@
     }
 
     const filtered = distribution.features
-      .filter(containedIn(event.detail, loop))
+      .filter(containedIn(distRange, loop))
       .map((feature) => feature.properties.stationId);
 
     filteredObservations.set(new Set(filtered));

--- a/services/ui/src/js/components/DiagnosticView/LoopDisplay.svelte
+++ b/services/ui/src/js/components/DiagnosticView/LoopDisplay.svelte
@@ -57,7 +57,7 @@
 
     region.set(event.detail);
 
-    if (event.detail === null) {
+    if (event.detail === null || event.detail[0] === event.detail[1]) {
       filteredObservations.set(new Set());
       return;
     }


### PR DESCRIPTION
Replaces the direction/magnitude plot with just the u, v coordinates. The brushing is behaving oddly, but I think that may actually be because I can’t rely on the station ID as a filter. I think we’ll need to put some more thought into what it means to select a region of one chart and how that affects the other charts, because from loop to loop, we can have different numbers of observations.

Probably the only way to uniquely identify an observation is a combination of observation time and location. Station ID might just have to be additional metadata, rather than a useful key.