### PR TITLE
Fix CI for dependabot

### DIFF
--- a/.github/workflows/api.yaml
+++ b/.github/workflows/api.yaml
@@ -148,6 +148,7 @@ jobs:
         with:
           sarif_file: 'trivy-results.sarif'
   deploy:
+    if: ${{ github.actor != "dependabot[bot]" }} # Don't deploy Dependabot changes
     runs-on: ubuntu-latest
     environment: vlab
     concurrency: vlab

--- a/.github/workflows/data.yaml
+++ b/.github/workflows/data.yaml
@@ -63,6 +63,8 @@ jobs:
         run: poetry run mypy src/
   test:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - uses: actions/checkout@v3
       - name: Install poetry
@@ -103,6 +105,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     needs: [lint, type-check, test]
+    permissions:
+      packages: write
     steps:
       - uses: actions/checkout@v3
       - name: Extract branch/tag name

--- a/.github/workflows/data.yaml
+++ b/.github/workflows/data.yaml
@@ -148,6 +148,7 @@ jobs:
         with:
           sarif_file: 'trivy-results.sarif'
   deploy:
+    if: ${{ github.actor != "dependabot[bot]" }} # Don't deploy Dependabot changes
     runs-on: ubuntu-latest
     environment: vlab
     concurrency: vlab

--- a/.github/workflows/ui.yaml
+++ b/.github/workflows/ui.yaml
@@ -123,6 +123,7 @@ jobs:
         with:
           sarif_file: 'trivy-results.sarif'
   deploy:
+    if: ${{ github.actor != "dependabot[bot]" }} # Don't deploy Dependabot changes
     runs-on: ubuntu-latest
     environment: vlab
     concurrency: vlab


### PR DESCRIPTION
The data service pipeline wasn't granting the permissions Dependabot needed and we don't really need to send the Dependabot container images to VLab.