### PR TITLE
Double quotes aren't valid in GitHub Actions literals

### DIFF
--- a/.github/workflows/api-cleanup-pr-images.yaml
+++ b/.github/workflows/api-cleanup-pr-images.yaml
@@ -22,6 +22,7 @@ jobs:
   purge-ecr-images:
     name: Cleanup PR images from ECR
     runs-on: ubuntu-latest
+    if: ${{ github.actor != 'dependabot[bot]' }} # Dependabot changes aren't sent to VLab
     environment: vlab
     concurrency: vlab
     steps:

--- a/.github/workflows/api.yaml
+++ b/.github/workflows/api.yaml
@@ -148,7 +148,7 @@ jobs:
         with:
           sarif_file: 'trivy-results.sarif'
   deploy:
-    if: ${{ github.actor != "dependabot[bot]" }} # Don't deploy Dependabot changes
+    if: ${{ github.actor != 'dependabot[bot]' }} # Don't deploy Dependabot changes
     runs-on: ubuntu-latest
     environment: vlab
     concurrency: vlab

--- a/.github/workflows/data-cleanup-pr-images.yaml
+++ b/.github/workflows/data-cleanup-pr-images.yaml
@@ -22,6 +22,7 @@ jobs:
   purge-ecr-images:
     name: Cleanup PR images from ECR
     runs-on: ubuntu-latest
+    if: ${{ github.actor != 'dependabot[bot]' }} # Dependabot changes aren't sent to VLab
     environment: vlab
     concurrency: vlab
     steps:

--- a/.github/workflows/data.yaml
+++ b/.github/workflows/data.yaml
@@ -148,7 +148,7 @@ jobs:
         with:
           sarif_file: 'trivy-results.sarif'
   deploy:
-    if: ${{ github.actor != "dependabot[bot]" }} # Don't deploy Dependabot changes
+    if: ${{ github.actor != 'dependabot[bot]' }} # Don't deploy Dependabot changes
     runs-on: ubuntu-latest
     environment: vlab
     concurrency: vlab

--- a/.github/workflows/ui-cleanup-pr-images.yaml
+++ b/.github/workflows/ui-cleanup-pr-images.yaml
@@ -23,6 +23,7 @@ jobs:
   purge-ecr-images:
     name: Cleanup PR images from ECR
     runs-on: ubuntu-latest
+    if: ${{ github.actor != 'dependabot[bot]' }} # Dependabot changes aren't sent to VLab
     environment: vlab
     concurrency: vlab
     steps:

--- a/.github/workflows/ui.yaml
+++ b/.github/workflows/ui.yaml
@@ -123,7 +123,7 @@ jobs:
         with:
           sarif_file: 'trivy-results.sarif'
   deploy:
-    if: ${{ github.actor != "dependabot[bot]" }} # Don't deploy Dependabot changes
+    if: ${{ github.actor != 'dependabot[bot]' }} # Don't deploy Dependabot changes
     runs-on: ubuntu-latest
     environment: vlab
     concurrency: vlab


### PR DESCRIPTION
They are valid YAML though. That's what I get for using a linter.
https://docs.github.com/en/actions/learn-github-actions/expressions#literals