### PR TITLE
Add Service Worker

### DIFF
--- a/services/ui/src/index.html
+++ b/services/ui/src/index.html
@@ -1,11 +1,32 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <link rel="icon" href="/favicon.png" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link rel="stylesheet" href="/styles/index.scss" />
-    <script type="module" src="/js/main.js"></script>
-  </head>
-  <body></body>
+
+<head>
+  <meta charset="utf-8" />
+  <link rel="icon" href="/favicon.png" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="stylesheet" href="/styles/index.scss" />
+  <script type="module" src="/js/main.js"></script>
+</head>
+
+<body>
+  <div id="app"></div>
+  <script>
+    async function registerServiceWorker() {
+      if (!("serviceWorker" in navigator)) return;
+
+      try {
+        const registration = await navigator.serviceWorker.register(
+          "/serviceworker.js",
+          {scope: "/"}
+        );
+      } catch (error) {
+        console.error(`Service Worker registration failed: ${error}`);
+      }
+    }
+
+    registerServiceWorker();
+  </script>
+</body>
+
 </html>

--- a/services/ui/src/index.html
+++ b/services/ui/src/index.html
@@ -1,32 +1,30 @@
 <!DOCTYPE html>
 <html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <link rel="icon" href="/favicon.png" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="stylesheet" href="/styles/index.scss" />
+    <script type="module" src="/js/main.js"></script>
+  </head>
 
-<head>
-  <meta charset="utf-8" />
-  <link rel="icon" href="/favicon.png" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <link rel="stylesheet" href="/styles/index.scss" />
-  <script type="module" src="/js/main.js"></script>
-</head>
+  <body>
+    <div id="app"></div>
+    <script>
+      async function registerServiceWorker() {
+        if (!("serviceWorker" in navigator)) return;
 
-<body>
-  <div id="app"></div>
-  <script>
-    async function registerServiceWorker() {
-      if (!("serviceWorker" in navigator)) return;
-
-      try {
-        const registration = await navigator.serviceWorker.register(
-          "/serviceworker.js",
-          {scope: "/"}
-        );
-      } catch (error) {
-        console.error(`Service Worker registration failed: ${error}`);
+        try {
+          const registration = await navigator.serviceWorker.register(
+            "/serviceworker.js",
+            { scope: "/" }
+          );
+        } catch (error) {
+          console.error(`Service Worker registration failed: ${error}`);
+        }
       }
-    }
 
-    registerServiceWorker();
-  </script>
-</body>
-
+      registerServiceWorker();
+    </script>
+  </body>
 </html>

--- a/services/ui/src/js/main.js
+++ b/services/ui/src/js/main.js
@@ -15,7 +15,7 @@ customElements.define("color-ramp", ColorRamp);
 customElements.define("loading-spinner", LoadingSpinner);
 
 const app = new App({
-  target: document.body,
+  target: document.getElementById("app"),
 });
 
 export default app;

--- a/services/ui/src/public/serviceworker.js
+++ b/services/ui/src/public/serviceworker.js
@@ -22,3 +22,38 @@ self.addEventListener("install", () => {
   // Don't wait to activate the new service worker in open tabs.
   self.skipWaiting();
 });
+
+async function addToCache(key, value) {
+  const cache = await caches.open(VERSION);
+  await cache.put(key, value);
+}
+
+async function respondFromCache({ request, preloadResponse }) {
+  const cachedResponse = await caches.match(request);
+  if (cachedResponse) {
+    console.info(`[${request.url}] Response loaded from cache`);
+    return cachedResponse;
+  }
+
+  const preloadResponsePromise = await preloadResponse;
+  if (preloadResponse) {
+    console.info(`[${request.url}] Response preloaded`);
+    addToCache(request, preloadResponsePromise.clone());
+    return preloadResponse;
+  }
+
+  try {
+    const response = await fetch(request);
+    addToCache(request, response.clone());
+    return response;
+  } catch (error) {
+    console.error(`[Network error] ${error}`);
+    return new Response("Network error", {
+      status: 400,
+      header: { "Content-Type": "text/plain" },
+    });
+  }
+}
+self.addEventListener("fetch", (event) => {
+  event.respondWith(respondFromCache(event));
+});

--- a/services/ui/src/public/serviceworker.js
+++ b/services/ui/src/public/serviceworker.js
@@ -1,0 +1,24 @@
+const VERSION = "20230228"; // eslint-disable-line no-unused-vars
+
+/**
+ * Enable navigation preload if it's supported.
+ *
+ * This function is async so that it can be called in ExtendableEvent.waitUntil
+ * during service worker activation. Navigation preload allows the browser to
+ * make network requests in parallel with service worker start up so that if we
+ * don't have the requested resource in the cache already, we get it sooner.
+ */
+async function enableNavigationPreload() {
+  if (self.registration.navigationPreload) {
+    await self.registration.navigationPreload.enable();
+  }
+}
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(enableNavigationPreload());
+});
+
+self.addEventListener("install", () => {
+  // Don't wait to activate the new service worker in open tabs.
+  self.skipWaiting();
+});

--- a/services/ui/src/styles/_default.scss
+++ b/services/ui/src/styles/_default.scss
@@ -1,13 +1,22 @@
 @mixin css {
+  #app,
   body {
+    overflow: clip;
+  }
+
+  #app {
     isolation: isolate;
     flex-direction: column;
 
     display: flex;
+
+    height: 100%;
   }
 
   main {
     flex: 1 1 auto;
+
+    overflow: auto;
 
     contain: strict;
   }


### PR DESCRIPTION
Implement a service worker to help cache data and speed up the application. The service worker intercepts all of our HTTP requests and prefers serving them from the application cache over network fetches. The service worker cache should hold onto things more reliably than the regular browser cache.

Additionally, we use the service worker to reduce duplicate network requests to cut down on bandwidth and ease the burden on our server.

After the first load when the service worker is installed, there is a dramatic increase in speed for the application even over slow network connections.
