### PR TITLE
Log non-test events that have no Records key

### DIFF
--- a/services/data/src/ugdata/aws.py
+++ b/services/data/src/ugdata/aws.py
@@ -51,6 +51,12 @@ def lambda_handler(event, context):
     if "Event" in event and event["Event"] == "s3:TestEvent":
         return "Test event received"
 
+    if "Records" not in event:
+        # FIXME: This should use a real logger
+        print("Records missing from event")
+        print(event)
+        return ""
+
     upload_bucket = os.environ["UG_DIAG_ZARR"]
 
     for record in event["Records"]:

--- a/services/data/tests/test_aws.py
+++ b/services/data/tests/test_aws.py
@@ -86,7 +86,7 @@ def test_handler(mock_fetch_record, mock_load, mock_save, monkeypatch):
     mock_save.assert_called_once_with(ug_bucket, mock_load.return_value)
 
 
-def test_hander_no_records(monkeypatch):
+def test_handler_no_records(monkeypatch):
     context = {}
     event = {}
     ug_bucket = "s3://test-bucket/test.zarr"

--- a/services/data/tests/test_aws.py
+++ b/services/data/tests/test_aws.py
@@ -86,6 +86,17 @@ def test_handler(mock_fetch_record, mock_load, mock_save, monkeypatch):
     mock_save.assert_called_once_with(ug_bucket, mock_load.return_value)
 
 
+def test_hander_no_records(monkeypatch):
+    context = {}
+    event = {}
+    ug_bucket = "s3://test-bucket/test.zarr"
+    monkeypatch.setenv("UG_DIAG_ZARR", ug_bucket)
+
+    result = aws.lambda_handler(event, context)
+
+    assert result == ""
+
+
 @mock.patch("ugdata.diag.save")
 @mock.patch("ugdata.diag.load")
 @mock.patch("ugdata.aws.fetch_record")


### PR DESCRIPTION
We should really convert this to a real logging handler, but we just
need a quick fix to see why the events we're getting in Lambda are
missing the "Records" key.
