### PR TITLE
Change Lambda handler for EventBridge events

### DIFF
--- a/services/data/tests/test_aws.py
+++ b/services/data/tests/test_aws.py
@@ -65,18 +65,10 @@ def test_handler(mock_fetch_record, mock_load, mock_save, monkeypatch):
 
     context = {}
     event = {
-        "Records": [
-            {
-                "s3": {
-                    "bucket": {
-                        "name": dl_bucket,
-                    },
-                    "object": {
-                        "key": key,
-                    },
-                }
-            }
-        ]
+        "detail": {
+            "bucket": {"name": dl_bucket},
+            "object": {"key": key},
+        }
     }
 
     aws.lambda_handler(event, context)
@@ -109,18 +101,10 @@ def test_handler_skip_second_loop(mock_fetch_record, mock_load, mock_save, monke
 
     context = {}
     event = {
-        "Records": [
-            {
-                "s3": {
-                    "bucket": {
-                        "name": dl_bucket,
-                    },
-                    "object": {
-                        "key": key,
-                    },
-                }
-            }
-        ]
+        "detail": {
+            "bucket": {"name": dl_bucket},
+            "object": {"key": key},
+        }
     }
 
     aws.lambda_handler(event, context)


### PR DESCRIPTION
We're not getting the kinds of events we expected from the S3 events.
Ian thinks this may have to do with the fact that VLab had to use
EventBridge to hook up our lambda function. The format we're expecting
now is the format we logged from the handler when we didn't get what we
expected, so hopefully this works.
