### PR TITLE
Network-first strategy for HTML caching

### DIFF
--- a/services/api/src/unified_graphics/static/serviceworker.js
+++ b/services/api/src/unified_graphics/static/serviceworker.js
@@ -1,4 +1,4 @@
-const VERSION = "20230309"; // eslint-disable-line no-unused-vars
+const VERSION = "20230309";
 
 const APP_CACHE = `app-${VERSION}`;
 const DATA_CACHE = `data-${VERSION}`;

--- a/services/api/src/unified_graphics/static/serviceworker.js
+++ b/services/api/src/unified_graphics/static/serviceworker.js
@@ -1,4 +1,4 @@
-const VERSION = "20230308"; // eslint-disable-line no-unused-vars
+const VERSION = "20230309"; // eslint-disable-line no-unused-vars
 
 const APP_CACHE = `app-${VERSION}`;
 const DATA_CACHE = `data-${VERSION}`;
@@ -40,13 +40,25 @@ function shouldCache(response) {
 }
 
 /**
- * Return `true` if `request` is for an app resource, not data.
+ * Return `true` if `request` is for an app resource.
  *
  * Any request for JSON is considered a data request. Everything else is an app resource.
  */
 function isAppResource(response) {
   const contentType = response.headers.get("Content-Type");
   return contentType !== "application/json";
+}
+
+/**
+ * Return `true` if `response` is something for which we prioritize cached responses.
+ *
+ * HTML documents prioritize the network over the cache, so this returns `false`
+ * when the content type of `response` is "text/html".
+ */
+function isCacheFirst(response) {
+  const contentType = response.headers.get("Content-Type");
+  const isHTML = contentType.includes("text/html");
+  return !isHTML;
 }
 
 /**
@@ -78,17 +90,17 @@ async function networkResponse(request) {
     // If we already have a fetch request for this URL, we'll use that response
     // instead of starting a new one.
     if (activeFetches.has(request.url)) {
-      console.info(`[respondFromCache] Fetch in progress for ${request.url}`);
+      console.info(`[networkResponse] Fetch in progress for ${request.url}`);
       response = await activeFetches.get(request.url);
     } else {
-      console.info(`[respondFromCache] Starting fetch for ${request.url}`);
+      console.info(`[networkResponse] Starting fetch for ${request.url}`);
       activeFetches.set(request.url, fetch(request));
       response = await activeFetches.get(request.url);
       addToCache(request, response.clone());
     }
     return response.clone();
   } catch (error) {
-    console.error(`[respondFromCache] Network error: ${error}`);
+    console.error(`[networkResponse] Network error: ${error}`);
     return new Response("Network error", {
       status: 400,
       header: { "Content-Type": "text/plain" },
@@ -103,7 +115,9 @@ async function respondFromCache(event) {
   const request = event.request;
 
   const cachedResponse = await caches.match(request);
-  if (cachedResponse) {
+  // If we have a cached response and we prioritize our cache for the response
+  // type, return the cached response.
+  if (cachedResponse && isCacheFirst(cachedResponse)) {
     console.info(`[respondFromCache] Response loaded from cache: ${request.url}`);
 
     // If this is a cached response for the App (HTML, CSS, JS), return the

--- a/services/api/src/unified_graphics/static/serviceworker.js
+++ b/services/api/src/unified_graphics/static/serviceworker.js
@@ -40,7 +40,7 @@ function shouldCache(response) {
 }
 
 /**
- * Return `true` if `request` is for an app resource.
+ * Return `true` if `response` is for an app resource.
  *
  * Any request for JSON is considered a data request. Everything else is an app resource.
  */


### PR DESCRIPTION
Prioritize the network for HTML documents, rather than using cached documents.
The HTML includes a <select> element for picking initialization times, which can
update fairly frequently. We don’t want someone seeing a stale list of available
runs just because they loaded up a run they looked at yesterday.
