### PR TITLE
Ignore Zellij kdl files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,6 +142,8 @@ node_modules/
 
 # Editor/IDE files
 *.code-*
+# Used by Zellij to define workspaces
+*.kdl
 *.sublime-*
 .vscode
 .idea


### PR DESCRIPTION
I have a KDL file in my project root to configure a project-specific Zellij
workspace. Tired of seeing it come up in `git status`.
