### PR TITLE
Bump mypy from 1.0.1 to 1.1.1

### DIFF
--- a/services/api/poetry.lock
+++ b/services/api/poetry.lock
@@ -1549,4 +1549,4 @@ jupyter = ["ipytree (>=0.2.2)", "ipywidgets (>=8.0.0)", "notebook"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "a62a262f2529baea194d307927e13497e610a456c7970c6d688bafd5189a74b6"
+content-hash = "e6cdab60b4e8974a63e5653c1d22127625a6937430686e67b5aee0ed81ff1ac9"

--- a/services/api/pyproject.toml
+++ b/services/api/pyproject.toml
@@ -18,7 +18,7 @@ zarr = "^2.13.6"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.2"
-mypy = "^1.0"
+mypy = "^1.1"
 black = "^23.1.0"
 flake8 = "^6.0.0"
 coverage = "^7.2.1"


### PR DESCRIPTION
I’m doing this update manually because there were some conflicts in the
dependabot PR that made me antsy.
