### PR TITLE
Switch to read_consolidated in get_model_metadata

### DIFF
--- a/services/api/src/unified_graphics/diag.py
+++ b/services/api/src/unified_graphics/diag.py
@@ -122,7 +122,7 @@ ModelMetadata = namedtuple(
 
 def get_model_metadata() -> ModelMetadata:
     store = get_store(current_app.config["DIAG_ZARR"])
-    z = zarr.open(store)
+    z = zarr.convenience.open_consolidated(store)
 
     model_list = set()
     system_list = set()


### PR DESCRIPTION
Reading the arrays out of the Zarr in S3 was so slow it was causing
gateway timeouts. It looks like reading the consolidated metadata is
much faster, and should hopefully unstick the application in production
until we can implement some more performant data handling.
