### PR TITLE
Reduce Dependabot version updates to once a month

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,20 +15,20 @@ updates:
   - package-ecosystem: "pip"
     directory: "/services/api"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     pull-request-branch-name:
       separator: "-" # Use "-" instead of "/" in branch names to avoid issues with docker registries
 
   - package-ecosystem: "pip"
     directory: "/services/data"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     pull-request-branch-name:
       separator: "-" # Use "-" instead of "/" in branch names to avoid issues with docker registries
 
   - package-ecosystem: "npm"
     directory: "/services/api"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     pull-request-branch-name:
       separator: "-" # Use "-" instead of "/" in branch names to avoid issues with docker registries


### PR DESCRIPTION
The weekly scans were getting quite noisy. Unfortunately there doesn't appear to be a way to do security updates weekly while reducing version updates to a monthly run. The GitHub Actions check hasn't been as noisy so it seems okay to leave that at a weekly cadence.