### PR TITLE
Increase the number of workers in the API service

### DIFF
--- a/services/api/Dockerfile
+++ b/services/api/Dockerfile
@@ -13,4 +13,5 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 EXPOSE 80
-CMD ["gunicorn", "unified_graphics.wsgi:app", "--bind=0.0.0.0:80", "--timeout=600"]
+# Gunicorn recommends setting the number of workers to be 2-4 * num_cores
+CMD ["gunicorn", "unified_graphics.wsgi:app", "--bind=0.0.0.0:80", "--timeout=600", "--workers=4"]


### PR DESCRIPTION
Gunicorn recommends using 2-4*num_cores workers. Starting conservatively with 4 workers. Unfortunately Docker's `CMD` directive won't expand environment variables when used with JSON syntax. We could use the `CMD` directive in shell mode in order to expand the env variable. However, that has its own issues with PID reaping which is something Gunicorn handles when it's called with JSON syntax and given PID 1.