### PR TITLE
Switch our images to non-root users

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,13 @@ updates:
     pull-request-branch-name:
       separator: "-" # Use "-" instead of "/" in branch names to avoid issues with docker registries
 
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    pull-request-branch-name:
+      separator: "-" # Use "-" instead of "/" in branch names to avoid issues with docker registries
+
   - package-ecosystem: "pip"
     directory: "/services/api"
     schedule:

--- a/services/api/Dockerfile
+++ b/services/api/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11
+FROM python:3.11-slim-bullseye
 
 WORKDIR /usr/src/app
 
@@ -7,10 +7,11 @@ RUN pip3 install --no-cache-dir gunicorn poetry \
 
 COPY . .
 
-RUN poetry install --no-interaction --no-ansi --no-dev
 RUN apt-get update \
+    && apt-get install -y build-essential \
     && apt-get upgrade -y \
     && rm -rf /var/lib/apt/lists/*
+RUN poetry install --no-interaction --no-ansi --no-dev
 
 RUN groupadd -g 1000 python && \
     useradd -r -u 1000 -g python python

--- a/services/api/Dockerfile
+++ b/services/api/Dockerfile
@@ -12,6 +12,11 @@ RUN apt-get update \
     && apt-get upgrade -y \
     && rm -rf /var/lib/apt/lists/*
 
+RUN groupadd -g 1000 python && \
+    useradd -r -u 1000 -g python python
+
+USER 1000
+
 EXPOSE 80
 # Gunicorn recommends setting the number of workers to be 2-4 * num_cores
 CMD ["gunicorn", "unified_graphics.wsgi:app", "--bind=0.0.0.0:80", "--timeout=600", "--workers=4"]

--- a/services/api/Dockerfile-webserver
+++ b/services/api/Dockerfile-webserver
@@ -7,10 +7,10 @@ RUN npm clean-install
 COPY src/unified_graphics/static/ src/unified_graphics/static/
 RUN npm run vendor && npm run build
 
-FROM nginx:1.21
+FROM nginxinc/nginx-unprivileged:1.24
 
 COPY --from=build /home/node/app/build /usr/share/nginx/html/static
 COPY default.conf.template /etc/nginx/templates/
-RUN apt-get update \
-    && apt-get upgrade -y \
-    && rm -rf /var/lib/apt/lists/*
+
+# The default port exposed by the unprivileged image is 8080
+EXPOSE 80


### PR DESCRIPTION
Switch the API and UI images to run as a non-root user. Use UID & GID 1000 to match VLab's preferences in the API image and use the built-in nginx user (uid/gid 101) in the `nginx-unprivileged` image. Additionally, switch our Python image to be based on a debian-slim variant to reduce image size and possible security issues.