### PR TITLE
Add support for stripping prefixes from the S3 key

### DIFF
--- a/services/data/src/ugdata/aws.py
+++ b/services/data/src/ugdata/aws.py
@@ -29,9 +29,9 @@ def fetch_record(bucket: str, key: str, download_path: str = "/tmp") -> Path:
     pathlib.Path
         The path to the downloaded file
     """
-    tmp_key = key.replace("/", "_")
-    if key_prefix := os.environ.get("UG_DIAG_KEY_PREFIX"):
-        tmp_key = tmp_key.removeprefix(key_prefix).removeprefix("_")
+    key_prefix = os.environ.get("UG_DIAG_KEY_PREFIX")
+    tmp_key = key.removeprefix(key_prefix).removeprefix("/") if key_prefix else key
+    tmp_key = tmp_key.replace("/", "_")
 
     tmp_path = Path(download_path) / f"{uuid.uuid4()}-{tmp_key}"
     s3_client.download_file(bucket, key, str(tmp_path))

--- a/services/data/src/ugdata/aws.py
+++ b/services/data/src/ugdata/aws.py
@@ -30,6 +30,9 @@ def fetch_record(bucket: str, key: str, download_path: str = "/tmp") -> Path:
         The path to the downloaded file
     """
     tmp_key = key.replace("/", "_")
+    if key_prefix := os.environ.get("UG_DIAG_KEY_PREFIX"):
+        tmp_key = tmp_key.removeprefix(key_prefix).removeprefix("_")
+
     tmp_path = Path(download_path) / f"{uuid.uuid4()}-{tmp_key}"
     s3_client.download_file(bucket, key, str(tmp_path))
 

--- a/services/data/tests/test_aws.py
+++ b/services/data/tests/test_aws.py
@@ -37,6 +37,12 @@ from ugdata import aws
             "/tmp/mock-uuid-RTMA_foo_ncdiag_conv_t_anl.nc4.2023013006",
             "diag",
         ),
+        (
+            "diag/RTMA/foo/ncdiag_conv_t_anl.nc4.2023013006",
+            "/tmp/mock-uuid-RTMA_foo_ncdiag_conv_t_anl.nc4.2023013006",
+            "/tmp/mock-uuid-RTMA_foo_ncdiag_conv_t_anl.nc4.2023013006",
+            "diag/",
+        ),
     ],
 )
 def test_fetch_record(


### PR DESCRIPTION
Get the prefix to strip from a `UG_DIAG_KEY_PREFIX` environment variable. If no environment variable is set, don't strip any prefixes.