### PR TITLE
Remove the CORS middleware for dev

### DIFF
--- a/src/unified_graphics/__init__.py
+++ b/src/unified_graphics/__init__.py
@@ -5,12 +5,6 @@ from flask import Flask
 __version__ = "0.1.0"
 
 
-def cors(response):
-    """Add CORS header for frontend development"""
-    response.access_control_allow_origin = "http://localhost:3000"
-    return response
-
-
 def create_app(config=None):
     dictConfig(
         {
@@ -36,9 +30,6 @@ def create_app(config=None):
 
     app = Flask(__name__)
     app.config.from_prefixed_env()
-
-    if app.config.get("ENV", "production") == "development":
-        app.after_request(cors)
 
     from . import routes
 


### PR DESCRIPTION
Now that we have converted the application to a monolith instead of having separate frontend and API services, we no longer need the CORS header.