### PR TITLE
Add an experimental label to the site

### DIFF
--- a/src/unified_graphics/static/css/default.css
+++ b/src/unified_graphics/static/css/default.css
@@ -260,3 +260,9 @@
     outline-color: transparent;
   }
 }
+
+small.caps {
+  font-size: inherit;
+  font-variant: all-small-caps;
+  letter-spacing: 0.03em;
+}

--- a/src/unified_graphics/templates/includes/header.html
+++ b/src/unified_graphics/templates/includes/header.html
@@ -8,7 +8,10 @@
       <h1 class="heading-1">
         {%- if form.model -%}
         {{ form.model }} {{ form.initialization_time }}
-        {%- if variable %} &horbar; <span class="text-title">{{ variable }}</span>{% endif %}
+        {%- if variable %}
+        &horbar; <span class="text-title">{{ variable }}</span>
+        <small class="caps text-base-dark"><strong>Experimental</strong></small>
+        {%- endif %}
         {%- else -%}
         Please Select a Model Run
         {%- endif -%}


### PR DESCRIPTION
Make it clear that the model data on display is from experimental versions of the models. This may actually be something we want to capture in the database in the future, in case we display non-experimental models as well.