### PR TITLE
Add a logger to our lambda function

### DIFF
--- a/src/unified_graphics/etl/diag.py
+++ b/src/unified_graphics/etl/diag.py
@@ -1,3 +1,4 @@
+import logging
 import re
 from collections import namedtuple
 from datetime import datetime
@@ -9,6 +10,8 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from unified_graphics.models import Analysis, WeatherModel
+
+logger = logging.getLogger(__name__)
 
 DiagMeta = namedtuple(
     "DiagMeta",
@@ -232,6 +235,7 @@ def save(session: Session, path: Union[Path, str], *args: xr.Dataset):
     path : Path
         The path to the location of the Zarr
     """
+    logger.info("Started saving dataset to Zarr and the DB")
     for ds in args:
         model = ds.model or "Unknown"
         system = ds.system or "Unknown"
@@ -287,5 +291,8 @@ def save(session: Session, path: Union[Path, str], *args: xr.Dataset):
             analysis.model = wx_model
             session.add(analysis)
 
+        logger.info(f"Saving dataset to Zarr at: {path}")
         ds.to_zarr(path, group=group, mode="a")
+        logger.info("Saving dataset to Database")
         session.commit()
+        logger.info("Done saving dataset")


### PR DESCRIPTION
AWS has "helpfully" provided a default logger instance in their image. I needed to strip it out with `force:  True` in the logging config so that we could configure our own logger. There may be a better way to handle this but for now, this works.