### PR TITLE
Don't generate consolidated metadata for Zarr

### DIFF
--- a/src/unified_graphics/etl/aws.py
+++ b/src/unified_graphics/etl/aws.py
@@ -94,10 +94,10 @@ def lambda_handler(event, context):
     logger.info(f"Fetching record {bucket}:{key} to disk")
     tmp_file = fetch_record(bucket, key)
 
-    logging.info(f"Loading {bucket}:{key} from disk into memory")
+    logger.info(f"Loading {bucket}:{key} from disk into memory")
     data = diag.load(tmp_file)
 
-    logging.info(
+    logger.info(
         f"Saving {bucket}:{key} to the database and to the Zarr "
         f"store at: {upload_bucket}"
     )

--- a/src/unified_graphics/etl/diag.py
+++ b/src/unified_graphics/etl/diag.py
@@ -292,7 +292,7 @@ def save(session: Session, path: Union[Path, str], *args: xr.Dataset):
             session.add(analysis)
 
         logger.info(f"Saving dataset to Zarr at: {path}")
-        ds.to_zarr(path, group=group, mode="a")
+        ds.to_zarr(path, group=group, mode="a", consolidated=False)
         logger.info("Saving dataset to Database")
         session.commit()
         logger.info("Done saving dataset")


### PR DESCRIPTION
We now are using the database for this purpose. We also suspect that this is an expensive operation and is causing our Lambda ETL functions to timeout.