### PR TITLE
Always include minutes in initialization time

### DIFF
--- a/src/unified_graphics/etl/diag.py
+++ b/src/unified_graphics/etl/diag.py
@@ -79,6 +79,8 @@ def parse_diag_filename(filename: str) -> DiagMeta:
     init_time = f"{year}-{month}-{day}T{hour}"
     if minute:
         init_time += ":" + minute
+    else:
+        init_time += ":00"
 
     return DiagMeta(
         variables, loop, init_time, model, system, domain, frequency, background

--- a/tests/etl/test_extract.py
+++ b/tests/etl/test_extract.py
@@ -65,7 +65,7 @@ from unified_graphics.etl import diag
             "ncdiag_conv_ps_anl.2022050514.nc4",
             ["ps"],
             "anl",
-            "2022-05-05T14",
+            "2022-05-05T14:00",
             None,
             None,
             None,
@@ -76,7 +76,7 @@ from unified_graphics.etl import diag
             "ncdiag_conv_uv_ges.2023010204.nc4",
             ["u", "v"],
             "ges",
-            "2023-01-02T04",
+            "2023-01-02T04:00",
             None,
             None,
             None,
@@ -193,7 +193,7 @@ def test_load(
         variable, loop, init_time, model, system, domain, frequency, background
     )
     expected_init_time = (
-        f"{init_time[:4]}-{init_time[4:6]}-{init_time[6:8]}T{init_time[-2:]}"
+        f"{init_time[:4]}-{init_time[4:6]}-{init_time[6:8]}T{init_time[-2:]}:00"
     )
     expected = diag_dataset(
         variable,

--- a/tests/etl/test_save.py
+++ b/tests/etl/test_save.py
@@ -17,7 +17,7 @@ def zarr_file(tmp_path):
 
 @pytest.fixture(scope="module")
 def analysis():
-    init_time = "2022-05-05T14"
+    init_time = "2022-05-05T14:00"
     model = "RTMA"
     system = "WCOSS"
     domain = "CONUS"


### PR DESCRIPTION
To ensure that our Zarr groups have a uniform format, we append ":00" to the init time if the ingested NetCDF file has only a year, month, day, and hour for the init time.