### PR TITLE
Don't write Parquet files during etl

### DIFF
--- a/src/unified_graphics/etl/diag.py
+++ b/src/unified_graphics/etl/diag.py
@@ -317,20 +317,6 @@ def save(session: Session, path: Union[Path, str], *args: xr.Dataset):
         logger.info(f"Saving dataset to Zarr at: {path}")
         ds.to_zarr(path, group=group, mode="a", consolidated=False)
 
-        parquet_path = (
-            Path(path)
-            / ".."
-            / "_".join((model, background, system, domain, frequency))
-            / ds.name
-        )
-        logger.info(f"Saving dataframe to Parquet at: {parquet_path}")
-        prep_dataframe(ds).to_parquet(
-            parquet_path,
-            engine="pyarrow",
-            index=True,
-            partition_cols=["loop"],
-        )
-
         logger.info("Saving dataset to Database")
         session.commit()
 

--- a/tests/etl/test_save.py
+++ b/tests/etl/test_save.py
@@ -75,6 +75,7 @@ class TestSaveNew:
 
         xr.testing.assert_equal(result, dataset)
 
+    @pytest.mark.xfail
     def test_parquet_created(self, dataframe, parquet_file):
         result = pd.read_parquet(
             parquet_file / "ps",
@@ -150,6 +151,7 @@ class TestAddVariable:
         result = xr.open_zarr(zarr_file, group=group, consolidated=False)
         xr.testing.assert_equal(result, dataset[expected])
 
+    @pytest.mark.xfail
     @pytest.mark.parametrize("variable,expected", (("ps", 0), ("t", 1)))
     def test_parquet(self, dataframe, parquet_file, variable, expected):
         result = pd.read_parquet(
@@ -211,6 +213,7 @@ class TestAddLoop:
         result = xr.open_zarr(zarr_file, group=group, consolidated=False)
         xr.testing.assert_equal(result, dataset[expected])
 
+    @pytest.mark.xfail
     @pytest.mark.parametrize("loop,expected", (("ges", 0), ("anl", 1)))
     def test_parquet(self, dataframe, parquet_file, loop, expected):
         result = pd.read_parquet(
@@ -271,6 +274,7 @@ class TestAddAnalysis:
         result = xr.open_zarr(zarr_file, group=group, consolidated=False)
         xr.testing.assert_equal(result, dataset[expected])
 
+    @pytest.mark.xfail
     def test_parquet(self, dataframe, parquet_file):
         result = pd.read_parquet(
             parquet_file / "ps",


### PR DESCRIPTION
I think there's something wrong with writing Parquet from our Lambda function. Until we get that sorted, I'm reverting this because it's holding up the data pipeline.