### PR TITLE
Point pytest to our tests directory

### DIFF
--- a/.github/workflows/api.yaml
+++ b/.github/workflows/api.yaml
@@ -85,7 +85,7 @@ jobs:
           poetry install
       - name: Test
         run: |
-          poetry run coverage run -m pytest --tb=no
+          poetry run coverage run -m pytest --tb=no tests/
           poetry run coverage report
           poetry run coverage xml
       - name: Code Coverage Report


### PR DESCRIPTION
This speeds up test collection tremendously. Pytest takes about 2 minutes to check the entire project for tests, but if we point it at the tests/ directory, it takes 0.11s to collect all the tests. Since we don't have doctests in the code, there's no reason to have pytest check the whole project.