### PR TITLE
Test clean up

### DIFF
--- a/.github/workflows/api.yaml
+++ b/.github/workflows/api.yaml
@@ -87,7 +87,7 @@ jobs:
           poetry install
       - name: Test
         run: |
-          poetry run coverage run -m pytest --tb=no tests/
+          poetry run coverage run -m pytest tests/
           poetry run coverage report
           poetry run coverage xml
       - name: Code Coverage Report

--- a/poetry.lock
+++ b/poetry.lock
@@ -225,6 +225,43 @@ tests = ["attrs[tests-no-zope]", "zope-interface"]
 tests-no-zope = ["cloudpickle", "hypothesis", "mypy (>=1.1.1)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "pytest-xdist[psutil]"]
 
 [[package]]
+name = "aws-sam-translator"
+version = "1.70.0"
+description = "AWS SAM Translator is a library that transform SAM templates into AWS CloudFormation templates"
+category = "dev"
+optional = false
+python-versions = ">=3.7, <=4.0, !=4.0"
+files = [
+    {file = "aws-sam-translator-1.70.0.tar.gz", hash = "sha256:753288eda07b057e5350773b7617076962b59404d49cd05e2259ac96a7694436"},
+    {file = "aws_sam_translator-1.70.0-py3-none-any.whl", hash = "sha256:a2df321607d29791893707ef2ded9e79be00dbb71ac430696f6e6d7d0b0301a5"},
+]
+
+[package.dependencies]
+boto3 = ">=1.19.5,<2.0.0"
+jsonschema = ">=3.2,<5"
+pydantic = ">=1.8,<2.0"
+typing-extensions = ">=4.4,<5"
+
+[package.extras]
+dev = ["black (==23.1.0)", "boto3 (>=1.23,<2)", "boto3-stubs[appconfig,serverlessrepo] (>=1.19.5,<2.0.0)", "coverage (>=5.3,<8)", "dateparser (>=1.1,<2.0)", "importlib-metadata", "mypy (>=1.1.0,<1.2.0)", "parameterized (>=0.7,<1.0)", "pytest (>=6.2,<8)", "pytest-cov (>=2.10,<5)", "pytest-env (>=0.6,<1)", "pytest-rerunfailures (>=9.1,<12)", "pytest-xdist (>=2.5,<4)", "pyyaml (>=6.0,<7.0)", "requests (>=2.28,<3.0)", "ruamel.yaml (==0.17.21)", "ruff (==0.0.263)", "tenacity (>=8.0,<9.0)", "types-PyYAML (>=6.0,<7.0)", "types-jsonschema (>=3.2,<4.0)"]
+
+[[package]]
+name = "aws-xray-sdk"
+version = "2.12.0"
+description = "The AWS X-Ray SDK for Python (the SDK) enables Python developers to record and emit information from within their applications to the AWS X-Ray service."
+category = "dev"
+optional = false
+python-versions = "*"
+files = [
+    {file = "aws-xray-sdk-2.12.0.tar.gz", hash = "sha256:295afc237073a80956d7d4f27c31830edcb9a8ccca9ef8aa44990badef15e5b7"},
+    {file = "aws_xray_sdk-2.12.0-py2.py3-none-any.whl", hash = "sha256:30886e23cc2daadc1c06a76f25b071205e84848419d1ddf097b62a565e156542"},
+]
+
+[package.dependencies]
+botocore = ">=1.11.3"
+wrapt = "*"
+
+[[package]]
 name = "black"
 version = "23.3.0"
 description = "The uncompromising code formatter."
@@ -325,6 +362,119 @@ urllib3 = ">=1.25.4,<1.27"
 
 [package.extras]
 crt = ["awscrt (==0.16.9)"]
+
+[[package]]
+name = "certifi"
+version = "2023.5.7"
+description = "Python package for providing Mozilla's CA Bundle."
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "certifi-2023.5.7-py3-none-any.whl", hash = "sha256:c6c2e98f5c7869efca1f8916fed228dd91539f9f1b444c314c06eef02980c716"},
+    {file = "certifi-2023.5.7.tar.gz", hash = "sha256:0f0d56dc5a6ad56fd4ba36484d6cc34451e1c6548c61daad8c320169f91eddc7"},
+]
+
+[[package]]
+name = "cffi"
+version = "1.15.1"
+description = "Foreign Function Interface for Python calling C code."
+category = "dev"
+optional = false
+python-versions = "*"
+files = [
+    {file = "cffi-1.15.1-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:a66d3508133af6e8548451b25058d5812812ec3798c886bf38ed24a98216fab2"},
+    {file = "cffi-1.15.1-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:470c103ae716238bbe698d67ad020e1db9d9dba34fa5a899b5e21577e6d52ed2"},
+    {file = "cffi-1.15.1-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:9ad5db27f9cabae298d151c85cf2bad1d359a1b9c686a275df03385758e2f914"},
+    {file = "cffi-1.15.1-cp27-cp27m-win32.whl", hash = "sha256:b3bbeb01c2b273cca1e1e0c5df57f12dce9a4dd331b4fa1635b8bec26350bde3"},
+    {file = "cffi-1.15.1-cp27-cp27m-win_amd64.whl", hash = "sha256:e00b098126fd45523dd056d2efba6c5a63b71ffe9f2bbe1a4fe1716e1d0c331e"},
+    {file = "cffi-1.15.1-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:d61f4695e6c866a23a21acab0509af1cdfd2c013cf256bbf5b6b5e2695827162"},
+    {file = "cffi-1.15.1-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:ed9cb427ba5504c1dc15ede7d516b84757c3e3d7868ccc85121d9310d27eed0b"},
+    {file = "cffi-1.15.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:39d39875251ca8f612b6f33e6b1195af86d1b3e60086068be9cc053aa4376e21"},
+    {file = "cffi-1.15.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:285d29981935eb726a4399badae8f0ffdff4f5050eaa6d0cfc3f64b857b77185"},
+    {file = "cffi-1.15.1-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3eb6971dcff08619f8d91607cfc726518b6fa2a9eba42856be181c6d0d9515fd"},
+    {file = "cffi-1.15.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:21157295583fe8943475029ed5abdcf71eb3911894724e360acff1d61c1d54bc"},
+    {file = "cffi-1.15.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5635bd9cb9731e6d4a1132a498dd34f764034a8ce60cef4f5319c0541159392f"},
+    {file = "cffi-1.15.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2012c72d854c2d03e45d06ae57f40d78e5770d252f195b93f581acf3ba44496e"},
+    {file = "cffi-1.15.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dd86c085fae2efd48ac91dd7ccffcfc0571387fe1193d33b6394db7ef31fe2a4"},
+    {file = "cffi-1.15.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:fa6693661a4c91757f4412306191b6dc88c1703f780c8234035eac011922bc01"},
+    {file = "cffi-1.15.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:59c0b02d0a6c384d453fece7566d1c7e6b7bae4fc5874ef2ef46d56776d61c9e"},
+    {file = "cffi-1.15.1-cp310-cp310-win32.whl", hash = "sha256:cba9d6b9a7d64d4bd46167096fc9d2f835e25d7e4c121fb2ddfc6528fb0413b2"},
+    {file = "cffi-1.15.1-cp310-cp310-win_amd64.whl", hash = "sha256:ce4bcc037df4fc5e3d184794f27bdaab018943698f4ca31630bc7f84a7b69c6d"},
+    {file = "cffi-1.15.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:3d08afd128ddaa624a48cf2b859afef385b720bb4b43df214f85616922e6a5ac"},
+    {file = "cffi-1.15.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:3799aecf2e17cf585d977b780ce79ff0dc9b78d799fc694221ce814c2c19db83"},
+    {file = "cffi-1.15.1-cp311-cp311-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a591fe9e525846e4d154205572a029f653ada1a78b93697f3b5a8f1f2bc055b9"},
+    {file = "cffi-1.15.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3548db281cd7d2561c9ad9984681c95f7b0e38881201e157833a2342c30d5e8c"},
+    {file = "cffi-1.15.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:91fc98adde3d7881af9b59ed0294046f3806221863722ba7d8d120c575314325"},
+    {file = "cffi-1.15.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:94411f22c3985acaec6f83c6df553f2dbe17b698cc7f8ae751ff2237d96b9e3c"},
+    {file = "cffi-1.15.1-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:03425bdae262c76aad70202debd780501fabeaca237cdfddc008987c0e0f59ef"},
+    {file = "cffi-1.15.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:cc4d65aeeaa04136a12677d3dd0b1c0c94dc43abac5860ab33cceb42b801c1e8"},
+    {file = "cffi-1.15.1-cp311-cp311-win32.whl", hash = "sha256:a0f100c8912c114ff53e1202d0078b425bee3649ae34d7b070e9697f93c5d52d"},
+    {file = "cffi-1.15.1-cp311-cp311-win_amd64.whl", hash = "sha256:04ed324bda3cda42b9b695d51bb7d54b680b9719cfab04227cdd1e04e5de3104"},
+    {file = "cffi-1.15.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:50a74364d85fd319352182ef59c5c790484a336f6db772c1a9231f1c3ed0cbd7"},
+    {file = "cffi-1.15.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e263d77ee3dd201c3a142934a086a4450861778baaeeb45db4591ef65550b0a6"},
+    {file = "cffi-1.15.1-cp36-cp36m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:cec7d9412a9102bdc577382c3929b337320c4c4c4849f2c5cdd14d7368c5562d"},
+    {file = "cffi-1.15.1-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4289fc34b2f5316fbb762d75362931e351941fa95fa18789191b33fc4cf9504a"},
+    {file = "cffi-1.15.1-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:173379135477dc8cac4bc58f45db08ab45d228b3363adb7af79436135d028405"},
+    {file = "cffi-1.15.1-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:6975a3fac6bc83c4a65c9f9fcab9e47019a11d3d2cf7f3c0d03431bf145a941e"},
+    {file = "cffi-1.15.1-cp36-cp36m-win32.whl", hash = "sha256:2470043b93ff09bf8fb1d46d1cb756ce6132c54826661a32d4e4d132e1977adf"},
+    {file = "cffi-1.15.1-cp36-cp36m-win_amd64.whl", hash = "sha256:30d78fbc8ebf9c92c9b7823ee18eb92f2e6ef79b45ac84db507f52fbe3ec4497"},
+    {file = "cffi-1.15.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:198caafb44239b60e252492445da556afafc7d1e3ab7a1fb3f0584ef6d742375"},
+    {file = "cffi-1.15.1-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5ef34d190326c3b1f822a5b7a45f6c4535e2f47ed06fec77d3d799c450b2651e"},
+    {file = "cffi-1.15.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8102eaf27e1e448db915d08afa8b41d6c7ca7a04b7d73af6514df10a3e74bd82"},
+    {file = "cffi-1.15.1-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5df2768244d19ab7f60546d0c7c63ce1581f7af8b5de3eb3004b9b6fc8a9f84b"},
+    {file = "cffi-1.15.1-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a8c4917bd7ad33e8eb21e9a5bbba979b49d9a97acb3a803092cbc1133e20343c"},
+    {file = "cffi-1.15.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0e2642fe3142e4cc4af0799748233ad6da94c62a8bec3a6648bf8ee68b1c7426"},
+    {file = "cffi-1.15.1-cp37-cp37m-win32.whl", hash = "sha256:e229a521186c75c8ad9490854fd8bbdd9a0c9aa3a524326b55be83b54d4e0ad9"},
+    {file = "cffi-1.15.1-cp37-cp37m-win_amd64.whl", hash = "sha256:a0b71b1b8fbf2b96e41c4d990244165e2c9be83d54962a9a1d118fd8657d2045"},
+    {file = "cffi-1.15.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:320dab6e7cb2eacdf0e658569d2575c4dad258c0fcc794f46215e1e39f90f2c3"},
+    {file = "cffi-1.15.1-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1e74c6b51a9ed6589199c787bf5f9875612ca4a8a0785fb2d4a84429badaf22a"},
+    {file = "cffi-1.15.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a5c84c68147988265e60416b57fc83425a78058853509c1b0629c180094904a5"},
+    {file = "cffi-1.15.1-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3b926aa83d1edb5aa5b427b4053dc420ec295a08e40911296b9eb1b6170f6cca"},
+    {file = "cffi-1.15.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:87c450779d0914f2861b8526e035c5e6da0a3199d8f1add1a665e1cbc6fc6d02"},
+    {file = "cffi-1.15.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4f2c9f67e9821cad2e5f480bc8d83b8742896f1242dba247911072d4fa94c192"},
+    {file = "cffi-1.15.1-cp38-cp38-win32.whl", hash = "sha256:8b7ee99e510d7b66cdb6c593f21c043c248537a32e0bedf02e01e9553a172314"},
+    {file = "cffi-1.15.1-cp38-cp38-win_amd64.whl", hash = "sha256:00a9ed42e88df81ffae7a8ab6d9356b371399b91dbdf0c3cb1e84c03a13aceb5"},
+    {file = "cffi-1.15.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:54a2db7b78338edd780e7ef7f9f6c442500fb0d41a5a4ea24fff1c929d5af585"},
+    {file = "cffi-1.15.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:fcd131dd944808b5bdb38e6f5b53013c5aa4f334c5cad0c72742f6eba4b73db0"},
+    {file = "cffi-1.15.1-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7473e861101c9e72452f9bf8acb984947aa1661a7704553a9f6e4baa5ba64415"},
+    {file = "cffi-1.15.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6c9a799e985904922a4d207a94eae35c78ebae90e128f0c4e521ce339396be9d"},
+    {file = "cffi-1.15.1-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3bcde07039e586f91b45c88f8583ea7cf7a0770df3a1649627bf598332cb6984"},
+    {file = "cffi-1.15.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:33ab79603146aace82c2427da5ca6e58f2b3f2fb5da893ceac0c42218a40be35"},
+    {file = "cffi-1.15.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5d598b938678ebf3c67377cdd45e09d431369c3b1a5b331058c338e201f12b27"},
+    {file = "cffi-1.15.1-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:db0fbb9c62743ce59a9ff687eb5f4afbe77e5e8403d6697f7446e5f609976f76"},
+    {file = "cffi-1.15.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:98d85c6a2bef81588d9227dde12db8a7f47f639f4a17c9ae08e773aa9c697bf3"},
+    {file = "cffi-1.15.1-cp39-cp39-win32.whl", hash = "sha256:40f4774f5a9d4f5e344f31a32b5096977b5d48560c5592e2f3d2c4374bd543ee"},
+    {file = "cffi-1.15.1-cp39-cp39-win_amd64.whl", hash = "sha256:70df4e3b545a17496c9b3f41f5115e69a4f2e77e94e1d2a8e1070bc0c38c8a3c"},
+    {file = "cffi-1.15.1.tar.gz", hash = "sha256:d400bfb9a37b1351253cb402671cea7e89bdecc294e8016a707f6d1d8ac934f9"},
+]
+
+[package.dependencies]
+pycparser = "*"
+
+[[package]]
+name = "cfn-lint"
+version = "0.77.10"
+description = "Checks CloudFormation templates for practices and behaviour that could potentially be improved"
+category = "dev"
+optional = false
+python-versions = ">=3.7, <=4.0, !=4.0"
+files = [
+    {file = "cfn-lint-0.77.10.tar.gz", hash = "sha256:c3bd6f5ae12641b6f99e100a4654e12448a9e16a0e0579afec8369709e12c904"},
+    {file = "cfn_lint-0.77.10-py3-none-any.whl", hash = "sha256:88ecb273a1a1770f206b957374cf33cb0b0779d14da482e9800e879897af9fa0"},
+]
+
+[package.dependencies]
+aws-sam-translator = ">=1.68.0"
+jschema-to-python = ">=1.2.3,<1.3.0"
+jsonpatch = "*"
+jsonschema = ">=3.0,<5"
+junit-xml = ">=1.9,<2.0"
+networkx = ">=2.4,<4"
+pyyaml = ">5.4"
+regex = "*"
+sarif-om = ">=1.0.4,<1.1.0"
+sympy = ">=1.0.0"
 
 [[package]]
 name = "cftime"
@@ -537,6 +687,89 @@ files = [
 toml = ["tomli"]
 
 [[package]]
+name = "cryptography"
+version = "41.0.1"
+description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "cryptography-41.0.1-cp37-abi3-macosx_10_12_universal2.whl", hash = "sha256:f73bff05db2a3e5974a6fd248af2566134d8981fd7ab012e5dd4ddb1d9a70699"},
+    {file = "cryptography-41.0.1-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:1a5472d40c8f8e91ff7a3d8ac6dfa363d8e3138b961529c996f3e2df0c7a411a"},
+    {file = "cryptography-41.0.1-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7fa01527046ca5facdf973eef2535a27fec4cb651e4daec4d043ef63f6ecd4ca"},
+    {file = "cryptography-41.0.1-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b46e37db3cc267b4dea1f56da7346c9727e1209aa98487179ee8ebed09d21e43"},
+    {file = "cryptography-41.0.1-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:d198820aba55660b4d74f7b5fd1f17db3aa5eb3e6893b0a41b75e84e4f9e0e4b"},
+    {file = "cryptography-41.0.1-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:948224d76c4b6457349d47c0c98657557f429b4e93057cf5a2f71d603e2fc3a3"},
+    {file = "cryptography-41.0.1-cp37-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:059e348f9a3c1950937e1b5d7ba1f8e968508ab181e75fc32b879452f08356db"},
+    {file = "cryptography-41.0.1-cp37-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:b4ceb5324b998ce2003bc17d519080b4ec8d5b7b70794cbd2836101406a9be31"},
+    {file = "cryptography-41.0.1-cp37-abi3-win32.whl", hash = "sha256:8f4ab7021127a9b4323537300a2acfb450124b2def3756f64dc3a3d2160ee4b5"},
+    {file = "cryptography-41.0.1-cp37-abi3-win_amd64.whl", hash = "sha256:1fee5aacc7367487b4e22484d3c7e547992ed726d14864ee33c0176ae43b0d7c"},
+    {file = "cryptography-41.0.1-pp38-pypy38_pp73-macosx_10_12_x86_64.whl", hash = "sha256:9a6c7a3c87d595608a39980ebaa04d5a37f94024c9f24eb7d10262b92f739ddb"},
+    {file = "cryptography-41.0.1-pp38-pypy38_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:5d092fdfedaec4cbbffbf98cddc915ba145313a6fdaab83c6e67f4e6c218e6f3"},
+    {file = "cryptography-41.0.1-pp38-pypy38_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:1a8e6c2de6fbbcc5e14fd27fb24414507cb3333198ea9ab1258d916f00bc3039"},
+    {file = "cryptography-41.0.1-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:cb33ccf15e89f7ed89b235cff9d49e2e62c6c981a6061c9c8bb47ed7951190bc"},
+    {file = "cryptography-41.0.1-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:5f0ff6e18d13a3de56f609dd1fd11470918f770c6bd5d00d632076c727d35485"},
+    {file = "cryptography-41.0.1-pp39-pypy39_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:7bfc55a5eae8b86a287747053140ba221afc65eb06207bedf6e019b8934b477c"},
+    {file = "cryptography-41.0.1-pp39-pypy39_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:eb8163f5e549a22888c18b0d53d6bb62a20510060a22fd5a995ec8a05268df8a"},
+    {file = "cryptography-41.0.1-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:8dde71c4169ec5ccc1087bb7521d54251c016f126f922ab2dfe6649170a3b8c5"},
+    {file = "cryptography-41.0.1.tar.gz", hash = "sha256:d34579085401d3f49762d2f7d6634d6b6c2ae1242202e860f4d26b046e3a1006"},
+]
+
+[package.dependencies]
+cffi = ">=1.12"
+
+[package.extras]
+docs = ["sphinx (>=5.3.0)", "sphinx-rtd-theme (>=1.1.1)"]
+docstest = ["pyenchant (>=1.6.11)", "sphinxcontrib-spelling (>=4.0.1)", "twine (>=1.12.0)"]
+nox = ["nox"]
+pep8test = ["black", "check-sdist", "mypy", "ruff"]
+sdist = ["build"]
+ssh = ["bcrypt (>=3.1.5)"]
+test = ["pretend", "pytest (>=6.2.0)", "pytest-benchmark", "pytest-cov", "pytest-xdist"]
+test-randomorder = ["pytest-randomly"]
+
+[[package]]
+name = "docker"
+version = "6.1.3"
+description = "A Python library for the Docker Engine API."
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "docker-6.1.3-py3-none-any.whl", hash = "sha256:aecd2277b8bf8e506e484f6ab7aec39abe0038e29fa4a6d3ba86c3fe01844ed9"},
+    {file = "docker-6.1.3.tar.gz", hash = "sha256:aa6d17830045ba5ef0168d5eaa34d37beeb113948c413affe1d5991fc11f9a20"},
+]
+
+[package.dependencies]
+packaging = ">=14.0"
+pywin32 = {version = ">=304", markers = "sys_platform == \"win32\""}
+requests = ">=2.26.0"
+urllib3 = ">=1.26.0"
+websocket-client = ">=0.32.0"
+
+[package.extras]
+ssh = ["paramiko (>=2.4.3)"]
+
+[[package]]
+name = "ecdsa"
+version = "0.18.0"
+description = "ECDSA cryptographic signature library (pure python)"
+category = "dev"
+optional = false
+python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
+files = [
+    {file = "ecdsa-0.18.0-py2.py3-none-any.whl", hash = "sha256:80600258e7ed2f16b9aa1d7c295bd70194109ad5a30fdee0eaeefef1d4c559dd"},
+    {file = "ecdsa-0.18.0.tar.gz", hash = "sha256:190348041559e21b22a1d65cee485282ca11a6f81d503fddb84d5017e9ed1e49"},
+]
+
+[package.dependencies]
+six = ">=1.9.0"
+
+[package.extras]
+gmpy = ["gmpy"]
+gmpy2 = ["gmpy2"]
+
+[[package]]
 name = "entrypoints"
 version = "0.4"
 description = "Discover and load entry points from installed packages."
@@ -615,6 +848,21 @@ Werkzeug = ">=2.3.3"
 [package.extras]
 async = ["asgiref (>=3.2)"]
 dotenv = ["python-dotenv"]
+
+[[package]]
+name = "flask-cors"
+version = "4.0.0"
+description = "A Flask extension adding a decorator for CORS support"
+category = "dev"
+optional = false
+python-versions = "*"
+files = [
+    {file = "Flask-Cors-4.0.0.tar.gz", hash = "sha256:f268522fcb2f73e2ecdde1ef45e2fd5c71cc48fe03cffb4b441c6d1b40684eb0"},
+    {file = "Flask_Cors-4.0.0-py2.py3-none-any.whl", hash = "sha256:bc3492bfd6368d27cfe79c7821df5a8a319e1a6d5eab277a3794be19bdc51783"},
+]
+
+[package.dependencies]
+Flask = ">=0.9"
 
 [[package]]
 name = "flask-sqlalchemy"
@@ -751,6 +999,18 @@ sftp = ["paramiko"]
 smb = ["smbprotocol"]
 ssh = ["paramiko"]
 tqdm = ["tqdm"]
+
+[[package]]
+name = "graphql-core"
+version = "3.2.3"
+description = "GraphQL implementation for Python, a port of GraphQL.js, the JavaScript reference implementation for GraphQL."
+category = "dev"
+optional = false
+python-versions = ">=3.6,<4"
+files = [
+    {file = "graphql-core-3.2.3.tar.gz", hash = "sha256:06d2aad0ac723e35b1cb47885d3e5c45e956a53bc1b209a9fc5369007fe46676"},
+    {file = "graphql_core-3.2.3-py3-none-any.whl", hash = "sha256:5766780452bd5ec8ba133f8bf287dc92713e3868ddd83aee4faab9fc3e303dc3"},
+]
 
 [[package]]
 name = "greenlet"
@@ -985,6 +1245,178 @@ files = [
 ]
 
 [[package]]
+name = "jschema-to-python"
+version = "1.2.3"
+description = "Generate source code for Python classes from a JSON schema."
+category = "dev"
+optional = false
+python-versions = ">= 2.7"
+files = [
+    {file = "jschema_to_python-1.2.3-py3-none-any.whl", hash = "sha256:8a703ca7604d42d74b2815eecf99a33359a8dccbb80806cce386d5e2dd992b05"},
+    {file = "jschema_to_python-1.2.3.tar.gz", hash = "sha256:76ff14fe5d304708ccad1284e4b11f96a658949a31ee7faed9e0995279549b91"},
+]
+
+[package.dependencies]
+attrs = "*"
+jsonpickle = "*"
+pbr = "*"
+
+[[package]]
+name = "jsondiff"
+version = "2.0.0"
+description = "Diff JSON and JSON-like structures in Python"
+category = "dev"
+optional = false
+python-versions = "*"
+files = [
+    {file = "jsondiff-2.0.0-py3-none-any.whl", hash = "sha256:689841d66273fc88fc79f7d33f4c074774f4f214b6466e3aff0e5adaf889d1e0"},
+    {file = "jsondiff-2.0.0.tar.gz", hash = "sha256:2795844ef075ec8a2b8d385c4d59f5ea48b08e7180fce3cb2787be0db00b1fb4"},
+]
+
+[[package]]
+name = "jsonpatch"
+version = "1.33"
+description = "Apply JSON-Patches (RFC 6902)"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, !=3.6.*"
+files = [
+    {file = "jsonpatch-1.33-py2.py3-none-any.whl", hash = "sha256:0ae28c0cd062bbd8b8ecc26d7d164fbbea9652a1a3693f3b956c1eae5145dade"},
+    {file = "jsonpatch-1.33.tar.gz", hash = "sha256:9fcd4009c41e6d12348b4a0ff2563ba56a2923a7dfee731d004e212e1ee5030c"},
+]
+
+[package.dependencies]
+jsonpointer = ">=1.9"
+
+[[package]]
+name = "jsonpickle"
+version = "3.0.1"
+description = "Python library for serializing any arbitrary object graph into JSON"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "jsonpickle-3.0.1-py2.py3-none-any.whl", hash = "sha256:130d8b293ea0add3845de311aaba55e6d706d0bb17bc123bd2c8baf8a39ac77c"},
+    {file = "jsonpickle-3.0.1.tar.gz", hash = "sha256:032538804795e73b94ead410800ac387fdb6de98f8882ac957fcd247e3a85200"},
+]
+
+[package.extras]
+docs = ["jaraco.packaging (>=3.2)", "rst.linker (>=1.9)", "sphinx"]
+testing = ["ecdsa", "feedparser", "gmpy2", "numpy", "pandas", "pymongo", "pytest (>=3.5,!=3.7.3)", "pytest-black-multipy", "pytest-checkdocs (>=1.2.3)", "pytest-cov", "pytest-flake8 (>=1.1.1)", "scikit-learn", "sqlalchemy"]
+testing-libs = ["simplejson", "ujson"]
+
+[[package]]
+name = "jsonpointer"
+version = "2.4"
+description = "Identify specific nodes in a JSON document (RFC 6901)"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, !=3.6.*"
+files = [
+    {file = "jsonpointer-2.4-py2.py3-none-any.whl", hash = "sha256:15d51bba20eea3165644553647711d150376234112651b4f1811022aecad7d7a"},
+    {file = "jsonpointer-2.4.tar.gz", hash = "sha256:585cee82b70211fa9e6043b7bb89db6e1aa49524340dde8ad6b63206ea689d88"},
+]
+
+[[package]]
+name = "jsonschema"
+version = "4.17.3"
+description = "An implementation of JSON Schema validation for Python"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "jsonschema-4.17.3-py3-none-any.whl", hash = "sha256:a870ad254da1a8ca84b6a2905cac29d265f805acc57af304784962a2aa6508f6"},
+    {file = "jsonschema-4.17.3.tar.gz", hash = "sha256:0f864437ab8b6076ba6707453ef8f98a6a0d512a80e93f8abdb676f737ecb60d"},
+]
+
+[package.dependencies]
+attrs = ">=17.4.0"
+pyrsistent = ">=0.14.0,<0.17.0 || >0.17.0,<0.17.1 || >0.17.1,<0.17.2 || >0.17.2"
+
+[package.extras]
+format = ["fqdn", "idna", "isoduration", "jsonpointer (>1.13)", "rfc3339-validator", "rfc3987", "uri-template", "webcolors (>=1.11)"]
+format-nongpl = ["fqdn", "idna", "isoduration", "jsonpointer (>1.13)", "rfc3339-validator", "rfc3986-validator (>0.1.0)", "uri-template", "webcolors (>=1.11)"]
+
+[[package]]
+name = "jsonschema-spec"
+version = "0.1.6"
+description = "JSONSchema Spec with object-oriented paths"
+category = "dev"
+optional = false
+python-versions = ">=3.7.0,<4.0.0"
+files = [
+    {file = "jsonschema_spec-0.1.6-py3-none-any.whl", hash = "sha256:f2206d18c89d1824c1f775ba14ed039743b41a9167bd2c5bdb774b66b3ca0bbf"},
+    {file = "jsonschema_spec-0.1.6.tar.gz", hash = "sha256:90215863b56e212086641956b20127ccbf6d8a3a38343dad01d6a74d19482f76"},
+]
+
+[package.dependencies]
+jsonschema = ">=4.0.0,<4.18.0"
+pathable = ">=0.4.1,<0.5.0"
+PyYAML = ">=5.1"
+requests = ">=2.31.0,<3.0.0"
+
+[[package]]
+name = "junit-xml"
+version = "1.9"
+description = "Creates JUnit XML test result documents that can be read by tools such as Jenkins"
+category = "dev"
+optional = false
+python-versions = "*"
+files = [
+    {file = "junit-xml-1.9.tar.gz", hash = "sha256:de16a051990d4e25a3982b2dd9e89d671067548718866416faec14d9de56db9f"},
+    {file = "junit_xml-1.9-py2.py3-none-any.whl", hash = "sha256:ec5ca1a55aefdd76d28fcc0b135251d156c7106fa979686a4b48d62b761b4732"},
+]
+
+[package.dependencies]
+six = "*"
+
+[[package]]
+name = "lazy-object-proxy"
+version = "1.9.0"
+description = "A fast and thorough lazy object proxy."
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "lazy-object-proxy-1.9.0.tar.gz", hash = "sha256:659fb5809fa4629b8a1ac5106f669cfc7bef26fbb389dda53b3e010d1ac4ebae"},
+    {file = "lazy_object_proxy-1.9.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:b40387277b0ed2d0602b8293b94d7257e17d1479e257b4de114ea11a8cb7f2d7"},
+    {file = "lazy_object_proxy-1.9.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e8c6cfb338b133fbdbc5cfaa10fe3c6aeea827db80c978dbd13bc9dd8526b7d4"},
+    {file = "lazy_object_proxy-1.9.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:721532711daa7db0d8b779b0bb0318fa87af1c10d7fe5e52ef30f8eff254d0cd"},
+    {file = "lazy_object_proxy-1.9.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:66a3de4a3ec06cd8af3f61b8e1ec67614fbb7c995d02fa224813cb7afefee701"},
+    {file = "lazy_object_proxy-1.9.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:1aa3de4088c89a1b69f8ec0dcc169aa725b0ff017899ac568fe44ddc1396df46"},
+    {file = "lazy_object_proxy-1.9.0-cp310-cp310-win32.whl", hash = "sha256:f0705c376533ed2a9e5e97aacdbfe04cecd71e0aa84c7c0595d02ef93b6e4455"},
+    {file = "lazy_object_proxy-1.9.0-cp310-cp310-win_amd64.whl", hash = "sha256:ea806fd4c37bf7e7ad82537b0757999264d5f70c45468447bb2b91afdbe73a6e"},
+    {file = "lazy_object_proxy-1.9.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:946d27deaff6cf8452ed0dba83ba38839a87f4f7a9732e8f9fd4107b21e6ff07"},
+    {file = "lazy_object_proxy-1.9.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:79a31b086e7e68b24b99b23d57723ef7e2c6d81ed21007b6281ebcd1688acb0a"},
+    {file = "lazy_object_proxy-1.9.0-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f699ac1c768270c9e384e4cbd268d6e67aebcfae6cd623b4d7c3bfde5a35db59"},
+    {file = "lazy_object_proxy-1.9.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:bfb38f9ffb53b942f2b5954e0f610f1e721ccebe9cce9025a38c8ccf4a5183a4"},
+    {file = "lazy_object_proxy-1.9.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:189bbd5d41ae7a498397287c408617fe5c48633e7755287b21d741f7db2706a9"},
+    {file = "lazy_object_proxy-1.9.0-cp311-cp311-win32.whl", hash = "sha256:81fc4d08b062b535d95c9ea70dbe8a335c45c04029878e62d744bdced5141586"},
+    {file = "lazy_object_proxy-1.9.0-cp311-cp311-win_amd64.whl", hash = "sha256:f2457189d8257dd41ae9b434ba33298aec198e30adf2dcdaaa3a28b9994f6adb"},
+    {file = "lazy_object_proxy-1.9.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:d9e25ef10a39e8afe59a5c348a4dbf29b4868ab76269f81ce1674494e2565a6e"},
+    {file = "lazy_object_proxy-1.9.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cbf9b082426036e19c6924a9ce90c740a9861e2bdc27a4834fd0a910742ac1e8"},
+    {file = "lazy_object_proxy-1.9.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9f5fa4a61ce2438267163891961cfd5e32ec97a2c444e5b842d574251ade27d2"},
+    {file = "lazy_object_proxy-1.9.0-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:8fa02eaab317b1e9e03f69aab1f91e120e7899b392c4fc19807a8278a07a97e8"},
+    {file = "lazy_object_proxy-1.9.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:e7c21c95cae3c05c14aafffe2865bbd5e377cfc1348c4f7751d9dc9a48ca4bda"},
+    {file = "lazy_object_proxy-1.9.0-cp37-cp37m-win32.whl", hash = "sha256:f12ad7126ae0c98d601a7ee504c1122bcef553d1d5e0c3bfa77b16b3968d2734"},
+    {file = "lazy_object_proxy-1.9.0-cp37-cp37m-win_amd64.whl", hash = "sha256:edd20c5a55acb67c7ed471fa2b5fb66cb17f61430b7a6b9c3b4a1e40293b1671"},
+    {file = "lazy_object_proxy-1.9.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:2d0daa332786cf3bb49e10dc6a17a52f6a8f9601b4cf5c295a4f85854d61de63"},
+    {file = "lazy_object_proxy-1.9.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9cd077f3d04a58e83d04b20e334f678c2b0ff9879b9375ed107d5d07ff160171"},
+    {file = "lazy_object_proxy-1.9.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:660c94ea760b3ce47d1855a30984c78327500493d396eac4dfd8bd82041b22be"},
+    {file = "lazy_object_proxy-1.9.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:212774e4dfa851e74d393a2370871e174d7ff0ebc980907723bb67d25c8a7c30"},
+    {file = "lazy_object_proxy-1.9.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:f0117049dd1d5635bbff65444496c90e0baa48ea405125c088e93d9cf4525b11"},
+    {file = "lazy_object_proxy-1.9.0-cp38-cp38-win32.whl", hash = "sha256:0a891e4e41b54fd5b8313b96399f8b0e173bbbfc03c7631f01efbe29bb0bcf82"},
+    {file = "lazy_object_proxy-1.9.0-cp38-cp38-win_amd64.whl", hash = "sha256:9990d8e71b9f6488e91ad25f322898c136b008d87bf852ff65391b004da5e17b"},
+    {file = "lazy_object_proxy-1.9.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:9e7551208b2aded9c1447453ee366f1c4070602b3d932ace044715d89666899b"},
+    {file = "lazy_object_proxy-1.9.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5f83ac4d83ef0ab017683d715ed356e30dd48a93746309c8f3517e1287523ef4"},
+    {file = "lazy_object_proxy-1.9.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7322c3d6f1766d4ef1e51a465f47955f1e8123caee67dd641e67d539a534d006"},
+    {file = "lazy_object_proxy-1.9.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:18b78ec83edbbeb69efdc0e9c1cb41a3b1b1ed11ddd8ded602464c3fc6020494"},
+    {file = "lazy_object_proxy-1.9.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:09763491ce220c0299688940f8dc2c5d05fd1f45af1e42e636b2e8b2303e4382"},
+    {file = "lazy_object_proxy-1.9.0-cp39-cp39-win32.whl", hash = "sha256:9090d8e53235aa280fc9239a86ae3ea8ac58eff66a705fa6aa2ec4968b95c821"},
+    {file = "lazy_object_proxy-1.9.0-cp39-cp39-win_amd64.whl", hash = "sha256:db1c1722726f47e10e0b5fdbf15ac3b8adb58c091d12b3ab713965795036985f"},
+]
+
+[[package]]
 name = "mako"
 version = "1.2.4"
 description = "A super-fast templating language that borrows the best ideas from the existing templating languages."
@@ -1075,6 +1507,86 @@ files = [
     {file = "mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e"},
     {file = "mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325"},
 ]
+
+[[package]]
+name = "moto"
+version = "4.1.12"
+description = ""
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "moto-4.1.12-py2.py3-none-any.whl", hash = "sha256:6f40141ff2f3a309c19faa169433afdf48d28733d328b08a843021ae36f005d9"},
+    {file = "moto-4.1.12.tar.gz", hash = "sha256:25577e4cf55f05235f4efe78bcfeb5a7704fb75c16b426a5de2fc1e6b7b8545b"},
+]
+
+[package.dependencies]
+aws-xray-sdk = {version = ">=0.93,<0.96 || >0.96", optional = true, markers = "extra == \"server\""}
+boto3 = ">=1.9.201"
+botocore = ">=1.12.201"
+cfn-lint = {version = ">=0.40.0", optional = true, markers = "extra == \"server\""}
+cryptography = ">=3.3.1"
+docker = {version = ">=3.0.0", optional = true, markers = "extra == \"server\""}
+ecdsa = {version = "!=0.15", optional = true, markers = "extra == \"server\""}
+flask = {version = "<2.2.0 || >2.2.0,<2.2.1 || >2.2.1", optional = true, markers = "extra == \"server\""}
+flask-cors = {version = "*", optional = true, markers = "extra == \"server\""}
+graphql-core = {version = "*", optional = true, markers = "extra == \"server\""}
+Jinja2 = ">=2.10.1"
+jsondiff = {version = ">=1.1.2", optional = true, markers = "extra == \"server\""}
+openapi-spec-validator = {version = ">=0.2.8", optional = true, markers = "extra == \"server\""}
+py-partiql-parser = {version = "0.3.3", optional = true, markers = "extra == \"server\""}
+pyparsing = {version = ">=3.0.7", optional = true, markers = "extra == \"server\""}
+python-dateutil = ">=2.1,<3.0.0"
+python-jose = {version = ">=3.1.0,<4.0.0", extras = ["cryptography"], optional = true, markers = "extra == \"server\""}
+PyYAML = {version = ">=5.1", optional = true, markers = "extra == \"server\""}
+requests = ">=2.5"
+responses = ">=0.13.0"
+setuptools = {version = "*", optional = true, markers = "extra == \"server\""}
+sshpubkeys = {version = ">=3.1.0", optional = true, markers = "extra == \"server\""}
+werkzeug = ">=0.5,<2.2.0 || >2.2.0,<2.2.1 || >2.2.1"
+xmltodict = "*"
+
+[package.extras]
+all = ["PyYAML (>=5.1)", "aws-xray-sdk (>=0.93,!=0.96)", "cfn-lint (>=0.40.0)", "docker (>=3.0.0)", "ecdsa (!=0.15)", "graphql-core", "jsondiff (>=1.1.2)", "openapi-spec-validator (>=0.2.8)", "py-partiql-parser (==0.3.3)", "pyparsing (>=3.0.7)", "python-jose[cryptography] (>=3.1.0,<4.0.0)", "setuptools", "sshpubkeys (>=3.1.0)"]
+apigateway = ["PyYAML (>=5.1)", "ecdsa (!=0.15)", "openapi-spec-validator (>=0.2.8)", "python-jose[cryptography] (>=3.1.0,<4.0.0)"]
+apigatewayv2 = ["PyYAML (>=5.1)"]
+appsync = ["graphql-core"]
+awslambda = ["docker (>=3.0.0)"]
+batch = ["docker (>=3.0.0)"]
+cloudformation = ["PyYAML (>=5.1)", "aws-xray-sdk (>=0.93,!=0.96)", "cfn-lint (>=0.40.0)", "docker (>=3.0.0)", "ecdsa (!=0.15)", "graphql-core", "jsondiff (>=1.1.2)", "openapi-spec-validator (>=0.2.8)", "py-partiql-parser (==0.3.3)", "pyparsing (>=3.0.7)", "python-jose[cryptography] (>=3.1.0,<4.0.0)", "setuptools", "sshpubkeys (>=3.1.0)"]
+cognitoidp = ["ecdsa (!=0.15)", "python-jose[cryptography] (>=3.1.0,<4.0.0)"]
+ds = ["sshpubkeys (>=3.1.0)"]
+dynamodb = ["docker (>=3.0.0)", "py-partiql-parser (==0.3.3)"]
+dynamodbstreams = ["docker (>=3.0.0)", "py-partiql-parser (==0.3.3)"]
+ebs = ["sshpubkeys (>=3.1.0)"]
+ec2 = ["sshpubkeys (>=3.1.0)"]
+efs = ["sshpubkeys (>=3.1.0)"]
+eks = ["sshpubkeys (>=3.1.0)"]
+glue = ["pyparsing (>=3.0.7)"]
+iotdata = ["jsondiff (>=1.1.2)"]
+route53resolver = ["sshpubkeys (>=3.1.0)"]
+s3 = ["PyYAML (>=5.1)", "py-partiql-parser (==0.3.3)"]
+server = ["PyYAML (>=5.1)", "aws-xray-sdk (>=0.93,!=0.96)", "cfn-lint (>=0.40.0)", "docker (>=3.0.0)", "ecdsa (!=0.15)", "flask (!=2.2.0,!=2.2.1)", "flask-cors", "graphql-core", "jsondiff (>=1.1.2)", "openapi-spec-validator (>=0.2.8)", "py-partiql-parser (==0.3.3)", "pyparsing (>=3.0.7)", "python-jose[cryptography] (>=3.1.0,<4.0.0)", "setuptools", "sshpubkeys (>=3.1.0)"]
+ssm = ["PyYAML (>=5.1)"]
+xray = ["aws-xray-sdk (>=0.93,!=0.96)", "setuptools"]
+
+[[package]]
+name = "mpmath"
+version = "1.3.0"
+description = "Python library for arbitrary-precision floating-point arithmetic"
+category = "dev"
+optional = false
+python-versions = "*"
+files = [
+    {file = "mpmath-1.3.0-py3-none-any.whl", hash = "sha256:a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c"},
+    {file = "mpmath-1.3.0.tar.gz", hash = "sha256:7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f"},
+]
+
+[package.extras]
+develop = ["codecov", "pycodestyle", "pytest (>=4.6)", "pytest-cov", "wheel"]
+docs = ["sphinx"]
+gmpy = ["gmpy2 (>=2.1.0a4)"]
+tests = ["pytest (>=4.6)"]
 
 [[package]]
 name = "multidict"
@@ -1261,6 +1773,25 @@ cftime = "*"
 numpy = "*"
 
 [[package]]
+name = "networkx"
+version = "3.1"
+description = "Python package for creating and manipulating graphs and networks"
+category = "dev"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "networkx-3.1-py3-none-any.whl", hash = "sha256:4f33f68cb2afcf86f28a45f43efc27a9386b535d567d2127f8f61d51dec58d36"},
+    {file = "networkx-3.1.tar.gz", hash = "sha256:de346335408f84de0eada6ff9fafafff9bcda11f0a0dfaa931133debb146ab61"},
+]
+
+[package.extras]
+default = ["matplotlib (>=3.4)", "numpy (>=1.20)", "pandas (>=1.3)", "scipy (>=1.8)"]
+developer = ["mypy (>=1.1)", "pre-commit (>=3.2)"]
+doc = ["nb2plots (>=0.6)", "numpydoc (>=1.5)", "pillow (>=9.4)", "pydata-sphinx-theme (>=0.13)", "sphinx (>=6.1)", "sphinx-gallery (>=0.12)", "texext (>=0.6.7)"]
+extra = ["lxml (>=4.6)", "pydot (>=1.4.2)", "pygraphviz (>=1.10)", "sympy (>=1.10)"]
+test = ["codecov (>=2.1)", "pytest (>=7.2)", "pytest-cov (>=4.0)"]
+
+[[package]]
 name = "numcodecs"
 version = "0.11.0"
 description = "A Python package providing buffer compression and transformation codecs for use"
@@ -1330,6 +1861,43 @@ files = [
     {file = "numpy-1.24.3-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:35400e6a8d102fd07c71ed7dcadd9eb62ee9a6e84ec159bd48c28235bbb0f8e4"},
     {file = "numpy-1.24.3.tar.gz", hash = "sha256:ab344f1bf21f140adab8e47fdbc7c35a477dc01408791f8ba00d018dd0bc5155"},
 ]
+
+[[package]]
+name = "openapi-schema-validator"
+version = "0.4.4"
+description = "OpenAPI schema validation for Python"
+category = "dev"
+optional = false
+python-versions = ">=3.7.0,<4.0.0"
+files = [
+    {file = "openapi_schema_validator-0.4.4-py3-none-any.whl", hash = "sha256:79f37f38ef9fd5206b924ed7a6f382cea7b649b3b56383c47f1906082b7b9015"},
+    {file = "openapi_schema_validator-0.4.4.tar.gz", hash = "sha256:c573e2be2c783abae56c5a1486ab716ca96e09d1c3eab56020d1dc680aa57bf8"},
+]
+
+[package.dependencies]
+jsonschema = ">=4.0.0,<4.18.0"
+rfc3339-validator = "*"
+
+[package.extras]
+docs = ["sphinx (>=5.3.0,<6.0.0)", "sphinx-immaterial (>=0.11.0,<0.12.0)"]
+
+[[package]]
+name = "openapi-spec-validator"
+version = "0.5.7"
+description = "OpenAPI 2.0 (aka Swagger) and OpenAPI 3 spec validator"
+category = "dev"
+optional = false
+python-versions = ">=3.7.0,<4.0.0"
+files = [
+    {file = "openapi_spec_validator-0.5.7-py3-none-any.whl", hash = "sha256:8712d2879db7692974ef89c47a3ebfc79436442921ec3a826ac0ce80cde8c549"},
+    {file = "openapi_spec_validator-0.5.7.tar.gz", hash = "sha256:6c2d42180045a80fd6314de848b94310bdb0fa4949f4b099578b69f79d9fa5ac"},
+]
+
+[package.dependencies]
+jsonschema = ">=4.0.0,<4.18.0"
+jsonschema-spec = ">=0.1.1,<0.2.0"
+lazy-object-proxy = ">=1.7.1,<2.0.0"
+openapi-schema-validator = ">=0.4.2,<0.5.0"
 
 [[package]]
 name = "packaging"
@@ -1424,6 +1992,18 @@ numpy = ">=1.24.3"
 types-pytz = ">=2022.1.1"
 
 [[package]]
+name = "pathable"
+version = "0.4.3"
+description = "Object-oriented paths"
+category = "dev"
+optional = false
+python-versions = ">=3.7.0,<4.0.0"
+files = [
+    {file = "pathable-0.4.3-py3-none-any.whl", hash = "sha256:cdd7b1f9d7d5c8b8d3315dbf5a86b2596053ae845f056f57d97c0eefff84da14"},
+    {file = "pathable-0.4.3.tar.gz", hash = "sha256:5c869d315be50776cc8a993f3af43e0c60dc01506b399643f919034ebf4cdcab"},
+]
+
+[[package]]
 name = "pathspec"
 version = "0.11.1"
 description = "Utility library for gitignore style pattern matching of file paths."
@@ -1433,6 +2013,18 @@ python-versions = ">=3.7"
 files = [
     {file = "pathspec-0.11.1-py3-none-any.whl", hash = "sha256:d8af70af76652554bd134c22b3e8a1cc46ed7d91edcdd721ef1a0c51a84a5293"},
     {file = "pathspec-0.11.1.tar.gz", hash = "sha256:2798de800fa92780e33acca925945e9a19a133b715067cf165b8866c15a31687"},
+]
+
+[[package]]
+name = "pbr"
+version = "5.11.1"
+description = "Python Build Reasonableness"
+category = "dev"
+optional = false
+python-versions = ">=2.6"
+files = [
+    {file = "pbr-5.11.1-py2.py3-none-any.whl", hash = "sha256:567f09558bae2b3ab53cb3c1e2e33e726ff3338e7bae3db5dc954b3a44eef12b"},
+    {file = "pbr-5.11.1.tar.gz", hash = "sha256:aefc51675b0b533d56bb5fd1c8c6c0522fe31896679882e1c4c63d5e4a0fccb3"},
 ]
 
 [[package]]
@@ -1573,6 +2165,21 @@ files = [
 typing-extensions = ">=3.10"
 
 [[package]]
+name = "py-partiql-parser"
+version = "0.3.3"
+description = "Pure Python PartiQL Parser"
+category = "dev"
+optional = false
+python-versions = "*"
+files = [
+    {file = "py-partiql-parser-0.3.3.tar.gz", hash = "sha256:351672721dfaaa00bbd82c4a3340d5d2defb589d2dd5baaecf6e493910f1c033"},
+    {file = "py_partiql_parser-0.3.3-py3-none-any.whl", hash = "sha256:cd4a53af362bb589968b17b321d1ac46d06d21d333247e0e6f79b11db2d0306f"},
+]
+
+[package.extras]
+dev = ["black (==22.6.0)", "flake8", "mypy (==0.971)", "pytest", "sure (==2.0.0)"]
+
+[[package]]
 name = "pyarrow"
 version = "12.0.1"
 description = "Python library for Apache Arrow"
@@ -1611,6 +2218,18 @@ files = [
 numpy = ">=1.16.6"
 
 [[package]]
+name = "pyasn1"
+version = "0.5.0"
+description = "Pure-Python implementation of ASN.1 types and DER/BER/CER codecs (X.208)"
+category = "dev"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,>=2.7"
+files = [
+    {file = "pyasn1-0.5.0-py2.py3-none-any.whl", hash = "sha256:87a2121042a1ac9358cabcaf1d07680ff97ee6404333bacca15f76aa8ad01a57"},
+    {file = "pyasn1-0.5.0.tar.gz", hash = "sha256:97b7290ca68e62a832558ec3976f15cbf911bf5d7c7039d8b861c2a0ece69fde"},
+]
+
+[[package]]
 name = "pycodestyle"
 version = "2.10.0"
 description = "Python style guide checker"
@@ -1623,6 +2242,71 @@ files = [
 ]
 
 [[package]]
+name = "pycparser"
+version = "2.21"
+description = "C parser in Python"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+files = [
+    {file = "pycparser-2.21-py2.py3-none-any.whl", hash = "sha256:8ee45429555515e1f6b185e78100aea234072576aa43ab53aefcae078162fca9"},
+    {file = "pycparser-2.21.tar.gz", hash = "sha256:e644fdec12f7872f86c58ff790da456218b10f863970249516d60a5eaca77206"},
+]
+
+[[package]]
+name = "pydantic"
+version = "1.10.9"
+description = "Data validation and settings management using python type hints"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "pydantic-1.10.9-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e692dec4a40bfb40ca530e07805b1208c1de071a18d26af4a2a0d79015b352ca"},
+    {file = "pydantic-1.10.9-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:3c52eb595db83e189419bf337b59154bdcca642ee4b2a09e5d7797e41ace783f"},
+    {file = "pydantic-1.10.9-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:939328fd539b8d0edf244327398a667b6b140afd3bf7e347cf9813c736211896"},
+    {file = "pydantic-1.10.9-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b48d3d634bca23b172f47f2335c617d3fcb4b3ba18481c96b7943a4c634f5c8d"},
+    {file = "pydantic-1.10.9-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:f0b7628fb8efe60fe66fd4adadd7ad2304014770cdc1f4934db41fe46cc8825f"},
+    {file = "pydantic-1.10.9-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:e1aa5c2410769ca28aa9a7841b80d9d9a1c5f223928ca8bec7e7c9a34d26b1d4"},
+    {file = "pydantic-1.10.9-cp310-cp310-win_amd64.whl", hash = "sha256:eec39224b2b2e861259d6f3c8b6290d4e0fbdce147adb797484a42278a1a486f"},
+    {file = "pydantic-1.10.9-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:d111a21bbbfd85c17248130deac02bbd9b5e20b303338e0dbe0faa78330e37e0"},
+    {file = "pydantic-1.10.9-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2e9aec8627a1a6823fc62fb96480abe3eb10168fd0d859ee3d3b395105ae19a7"},
+    {file = "pydantic-1.10.9-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:07293ab08e7b4d3c9d7de4949a0ea571f11e4557d19ea24dd3ae0c524c0c334d"},
+    {file = "pydantic-1.10.9-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7ee829b86ce984261d99ff2fd6e88f2230068d96c2a582f29583ed602ef3fc2c"},
+    {file = "pydantic-1.10.9-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:4b466a23009ff5cdd7076eb56aca537c745ca491293cc38e72bf1e0e00de5b91"},
+    {file = "pydantic-1.10.9-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:7847ca62e581e6088d9000f3c497267868ca2fa89432714e21a4fb33a04d52e8"},
+    {file = "pydantic-1.10.9-cp311-cp311-win_amd64.whl", hash = "sha256:7845b31959468bc5b78d7b95ec52fe5be32b55d0d09983a877cca6aedc51068f"},
+    {file = "pydantic-1.10.9-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:517a681919bf880ce1dac7e5bc0c3af1e58ba118fd774da2ffcd93c5f96eaece"},
+    {file = "pydantic-1.10.9-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:67195274fd27780f15c4c372f4ba9a5c02dad6d50647b917b6a92bf00b3d301a"},
+    {file = "pydantic-1.10.9-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2196c06484da2b3fded1ab6dbe182bdabeb09f6318b7fdc412609ee2b564c49a"},
+    {file = "pydantic-1.10.9-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:6257bb45ad78abacda13f15bde5886efd6bf549dd71085e64b8dcf9919c38b60"},
+    {file = "pydantic-1.10.9-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:3283b574b01e8dbc982080d8287c968489d25329a463b29a90d4157de4f2baaf"},
+    {file = "pydantic-1.10.9-cp37-cp37m-win_amd64.whl", hash = "sha256:5f8bbaf4013b9a50e8100333cc4e3fa2f81214033e05ac5aa44fa24a98670a29"},
+    {file = "pydantic-1.10.9-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:b9cd67fb763248cbe38f0593cd8611bfe4b8ad82acb3bdf2b0898c23415a1f82"},
+    {file = "pydantic-1.10.9-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:f50e1764ce9353be67267e7fd0da08349397c7db17a562ad036aa7c8f4adfdb6"},
+    {file = "pydantic-1.10.9-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:73ef93e5e1d3c8e83f1ff2e7fdd026d9e063c7e089394869a6e2985696693766"},
+    {file = "pydantic-1.10.9-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:128d9453d92e6e81e881dd7e2484e08d8b164da5507f62d06ceecf84bf2e21d3"},
+    {file = "pydantic-1.10.9-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:ad428e92ab68798d9326bb3e5515bc927444a3d71a93b4a2ca02a8a5d795c572"},
+    {file = "pydantic-1.10.9-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:fab81a92f42d6d525dd47ced310b0c3e10c416bbfae5d59523e63ea22f82b31e"},
+    {file = "pydantic-1.10.9-cp38-cp38-win_amd64.whl", hash = "sha256:963671eda0b6ba6926d8fc759e3e10335e1dc1b71ff2a43ed2efd6996634dafb"},
+    {file = "pydantic-1.10.9-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:970b1bdc6243ef663ba5c7e36ac9ab1f2bfecb8ad297c9824b542d41a750b298"},
+    {file = "pydantic-1.10.9-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:7e1d5290044f620f80cf1c969c542a5468f3656de47b41aa78100c5baa2b8276"},
+    {file = "pydantic-1.10.9-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:83fcff3c7df7adff880622a98022626f4f6dbce6639a88a15a3ce0f96466cb60"},
+    {file = "pydantic-1.10.9-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0da48717dc9495d3a8f215e0d012599db6b8092db02acac5e0d58a65248ec5bc"},
+    {file = "pydantic-1.10.9-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:0a2aabdc73c2a5960e87c3ffebca6ccde88665616d1fd6d3db3178ef427b267a"},
+    {file = "pydantic-1.10.9-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:9863b9420d99dfa9c064042304868e8ba08e89081428a1c471858aa2af6f57c4"},
+    {file = "pydantic-1.10.9-cp39-cp39-win_amd64.whl", hash = "sha256:e7c9900b43ac14110efa977be3da28931ffc74c27e96ee89fbcaaf0b0fe338e1"},
+    {file = "pydantic-1.10.9-py3-none-any.whl", hash = "sha256:6cafde02f6699ce4ff643417d1a9223716ec25e228ddc3b436fe7e2d25a1f305"},
+    {file = "pydantic-1.10.9.tar.gz", hash = "sha256:95c70da2cd3b6ddf3b9645ecaa8d98f3d80c606624b6d245558d202cd23ea3be"},
+]
+
+[package.dependencies]
+typing-extensions = ">=4.2.0"
+
+[package.extras]
+dotenv = ["python-dotenv (>=0.10.4)"]
+email = ["email-validator (>=1.0.3)"]
+
+[[package]]
 name = "pyflakes"
 version = "3.0.1"
 description = "passive checker of Python programs"
@@ -1632,6 +2316,58 @@ python-versions = ">=3.6"
 files = [
     {file = "pyflakes-3.0.1-py2.py3-none-any.whl", hash = "sha256:ec55bf7fe21fff7f1ad2f7da62363d749e2a470500eab1b555334b67aa1ef8cf"},
     {file = "pyflakes-3.0.1.tar.gz", hash = "sha256:ec8b276a6b60bd80defed25add7e439881c19e64850afd9b346283d4165fd0fd"},
+]
+
+[[package]]
+name = "pyparsing"
+version = "3.1.0"
+description = "pyparsing module - Classes and methods to define and execute parsing grammars"
+category = "dev"
+optional = false
+python-versions = ">=3.6.8"
+files = [
+    {file = "pyparsing-3.1.0-py3-none-any.whl", hash = "sha256:d554a96d1a7d3ddaf7183104485bc19fd80543ad6ac5bdb6426719d766fb06c1"},
+    {file = "pyparsing-3.1.0.tar.gz", hash = "sha256:edb662d6fe322d6e990b1594b5feaeadf806803359e3d4d42f11e295e588f0ea"},
+]
+
+[package.extras]
+diagrams = ["jinja2", "railroad-diagrams"]
+
+[[package]]
+name = "pyrsistent"
+version = "0.19.3"
+description = "Persistent/Functional/Immutable data structures"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "pyrsistent-0.19.3-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:20460ac0ea439a3e79caa1dbd560344b64ed75e85d8703943e0b66c2a6150e4a"},
+    {file = "pyrsistent-0.19.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4c18264cb84b5e68e7085a43723f9e4c1fd1d935ab240ce02c0324a8e01ccb64"},
+    {file = "pyrsistent-0.19.3-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4b774f9288dda8d425adb6544e5903f1fb6c273ab3128a355c6b972b7df39dcf"},
+    {file = "pyrsistent-0.19.3-cp310-cp310-win32.whl", hash = "sha256:5a474fb80f5e0d6c9394d8db0fc19e90fa540b82ee52dba7d246a7791712f74a"},
+    {file = "pyrsistent-0.19.3-cp310-cp310-win_amd64.whl", hash = "sha256:49c32f216c17148695ca0e02a5c521e28a4ee6c5089f97e34fe24163113722da"},
+    {file = "pyrsistent-0.19.3-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:f0774bf48631f3a20471dd7c5989657b639fd2d285b861237ea9e82c36a415a9"},
+    {file = "pyrsistent-0.19.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3ab2204234c0ecd8b9368dbd6a53e83c3d4f3cab10ecaf6d0e772f456c442393"},
+    {file = "pyrsistent-0.19.3-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e42296a09e83028b3476f7073fcb69ffebac0e66dbbfd1bd847d61f74db30f19"},
+    {file = "pyrsistent-0.19.3-cp311-cp311-win32.whl", hash = "sha256:64220c429e42a7150f4bfd280f6f4bb2850f95956bde93c6fda1b70507af6ef3"},
+    {file = "pyrsistent-0.19.3-cp311-cp311-win_amd64.whl", hash = "sha256:016ad1afadf318eb7911baa24b049909f7f3bb2c5b1ed7b6a8f21db21ea3faa8"},
+    {file = "pyrsistent-0.19.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:c4db1bd596fefd66b296a3d5d943c94f4fac5bcd13e99bffe2ba6a759d959a28"},
+    {file = "pyrsistent-0.19.3-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:aeda827381f5e5d65cced3024126529ddc4289d944f75e090572c77ceb19adbf"},
+    {file = "pyrsistent-0.19.3-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:42ac0b2f44607eb92ae88609eda931a4f0dfa03038c44c772e07f43e738bcac9"},
+    {file = "pyrsistent-0.19.3-cp37-cp37m-win32.whl", hash = "sha256:e8f2b814a3dc6225964fa03d8582c6e0b6650d68a232df41e3cc1b66a5d2f8d1"},
+    {file = "pyrsistent-0.19.3-cp37-cp37m-win_amd64.whl", hash = "sha256:c9bb60a40a0ab9aba40a59f68214eed5a29c6274c83b2cc206a359c4a89fa41b"},
+    {file = "pyrsistent-0.19.3-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:a2471f3f8693101975b1ff85ffd19bb7ca7dd7c38f8a81701f67d6b4f97b87d8"},
+    {file = "pyrsistent-0.19.3-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cc5d149f31706762c1f8bda2e8c4f8fead6e80312e3692619a75301d3dbb819a"},
+    {file = "pyrsistent-0.19.3-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3311cb4237a341aa52ab8448c27e3a9931e2ee09561ad150ba94e4cfd3fc888c"},
+    {file = "pyrsistent-0.19.3-cp38-cp38-win32.whl", hash = "sha256:f0e7c4b2f77593871e918be000b96c8107da48444d57005b6a6bc61fb4331b2c"},
+    {file = "pyrsistent-0.19.3-cp38-cp38-win_amd64.whl", hash = "sha256:c147257a92374fde8498491f53ffa8f4822cd70c0d85037e09028e478cababb7"},
+    {file = "pyrsistent-0.19.3-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:b735e538f74ec31378f5a1e3886a26d2ca6351106b4dfde376a26fc32a044edc"},
+    {file = "pyrsistent-0.19.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:99abb85579e2165bd8522f0c0138864da97847875ecbd45f3e7e2af569bfc6f2"},
+    {file = "pyrsistent-0.19.3-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3a8cb235fa6d3fd7aae6a4f1429bbb1fec1577d978098da1252f0489937786f3"},
+    {file = "pyrsistent-0.19.3-cp39-cp39-win32.whl", hash = "sha256:c74bed51f9b41c48366a286395c67f4e894374306b197e62810e0fdaf2364da2"},
+    {file = "pyrsistent-0.19.3-cp39-cp39-win_amd64.whl", hash = "sha256:878433581fc23e906d947a6814336eee031a00e6defba224234169ae3d3d6a98"},
+    {file = "pyrsistent-0.19.3-py3-none-any.whl", hash = "sha256:ccf0d6bd208f8111179f0c26fdf84ed7c3891982f2edaeae7422575f47e66b64"},
+    {file = "pyrsistent-0.19.3.tar.gz", hash = "sha256:1a2994773706bbb4995c31a97bc94f1418314923bd1048c6d964837040376440"},
 ]
 
 [[package]]
@@ -1688,6 +2424,29 @@ files = [
 cli = ["click (>=5.0)"]
 
 [[package]]
+name = "python-jose"
+version = "3.3.0"
+description = "JOSE implementation in Python"
+category = "dev"
+optional = false
+python-versions = "*"
+files = [
+    {file = "python-jose-3.3.0.tar.gz", hash = "sha256:55779b5e6ad599c6336191246e95eb2293a9ddebd555f796a65f838f07e5d78a"},
+    {file = "python_jose-3.3.0-py2.py3-none-any.whl", hash = "sha256:9b1376b023f8b298536eedd47ae1089bcdb848f1535ab30555cd92002d78923a"},
+]
+
+[package.dependencies]
+cryptography = {version = ">=3.4.0", optional = true, markers = "extra == \"cryptography\""}
+ecdsa = "!=0.15"
+pyasn1 = "*"
+rsa = "*"
+
+[package.extras]
+cryptography = ["cryptography (>=3.4.0)"]
+pycrypto = ["pyasn1", "pycrypto (>=2.6.0,<2.7.0)"]
+pycryptodome = ["pyasn1", "pycryptodome (>=3.3.1,<4.0.0)"]
+
+[[package]]
 name = "pytz"
 version = "2023.3"
 description = "World timezone definitions, modern and historical"
@@ -1698,6 +2457,251 @@ files = [
     {file = "pytz-2023.3-py2.py3-none-any.whl", hash = "sha256:a151b3abb88eda1d4e34a9814df37de2a80e301e68ba0fd856fb9b46bfbbbffb"},
     {file = "pytz-2023.3.tar.gz", hash = "sha256:1d8ce29db189191fb55338ee6d0387d82ab59f3d00eac103412d64e0ebd0c588"},
 ]
+
+[[package]]
+name = "pywin32"
+version = "306"
+description = "Python for Window Extensions"
+category = "dev"
+optional = false
+python-versions = "*"
+files = [
+    {file = "pywin32-306-cp310-cp310-win32.whl", hash = "sha256:06d3420a5155ba65f0b72f2699b5bacf3109f36acbe8923765c22938a69dfc8d"},
+    {file = "pywin32-306-cp310-cp310-win_amd64.whl", hash = "sha256:84f4471dbca1887ea3803d8848a1616429ac94a4a8d05f4bc9c5dcfd42ca99c8"},
+    {file = "pywin32-306-cp311-cp311-win32.whl", hash = "sha256:e65028133d15b64d2ed8f06dd9fbc268352478d4f9289e69c190ecd6818b6407"},
+    {file = "pywin32-306-cp311-cp311-win_amd64.whl", hash = "sha256:a7639f51c184c0272e93f244eb24dafca9b1855707d94c192d4a0b4c01e1100e"},
+    {file = "pywin32-306-cp311-cp311-win_arm64.whl", hash = "sha256:70dba0c913d19f942a2db25217d9a1b726c278f483a919f1abfed79c9cf64d3a"},
+    {file = "pywin32-306-cp312-cp312-win32.whl", hash = "sha256:383229d515657f4e3ed1343da8be101000562bf514591ff383ae940cad65458b"},
+    {file = "pywin32-306-cp312-cp312-win_amd64.whl", hash = "sha256:37257794c1ad39ee9be652da0462dc2e394c8159dfd913a8a4e8eb6fd346da0e"},
+    {file = "pywin32-306-cp312-cp312-win_arm64.whl", hash = "sha256:5821ec52f6d321aa59e2db7e0a35b997de60c201943557d108af9d4ae1ec7040"},
+    {file = "pywin32-306-cp37-cp37m-win32.whl", hash = "sha256:1c73ea9a0d2283d889001998059f5eaaba3b6238f767c9cf2833b13e6a685f65"},
+    {file = "pywin32-306-cp37-cp37m-win_amd64.whl", hash = "sha256:72c5f621542d7bdd4fdb716227be0dd3f8565c11b280be6315b06ace35487d36"},
+    {file = "pywin32-306-cp38-cp38-win32.whl", hash = "sha256:e4c092e2589b5cf0d365849e73e02c391c1349958c5ac3e9d5ccb9a28e017b3a"},
+    {file = "pywin32-306-cp38-cp38-win_amd64.whl", hash = "sha256:e8ac1ae3601bee6ca9f7cb4b5363bf1c0badb935ef243c4733ff9a393b1690c0"},
+    {file = "pywin32-306-cp39-cp39-win32.whl", hash = "sha256:e25fd5b485b55ac9c057f67d94bc203f3f6595078d1fb3b458c9c28b7153a802"},
+    {file = "pywin32-306-cp39-cp39-win_amd64.whl", hash = "sha256:39b61c15272833b5c329a2989999dcae836b1eed650252ab1b7bfbe1d59f30f4"},
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0"
+description = "YAML parser and emitter for Python"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "PyYAML-6.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d4db7c7aef085872ef65a8fd7d6d09a14ae91f691dec3e87ee5ee0539d516f53"},
+    {file = "PyYAML-6.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:9df7ed3b3d2e0ecfe09e14741b857df43adb5a3ddadc919a2d94fbdf78fea53c"},
+    {file = "PyYAML-6.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:77f396e6ef4c73fdc33a9157446466f1cff553d979bd00ecb64385760c6babdc"},
+    {file = "PyYAML-6.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a80a78046a72361de73f8f395f1f1e49f956c6be882eed58505a15f3e430962b"},
+    {file = "PyYAML-6.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:f84fbc98b019fef2ee9a1cb3ce93e3187a6df0b2538a651bfb890254ba9f90b5"},
+    {file = "PyYAML-6.0-cp310-cp310-win32.whl", hash = "sha256:2cd5df3de48857ed0544b34e2d40e9fac445930039f3cfe4bcc592a1f836d513"},
+    {file = "PyYAML-6.0-cp310-cp310-win_amd64.whl", hash = "sha256:daf496c58a8c52083df09b80c860005194014c3698698d1a57cbcfa182142a3a"},
+    {file = "PyYAML-6.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:d4b0ba9512519522b118090257be113b9468d804b19d63c71dbcf4a48fa32358"},
+    {file = "PyYAML-6.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:81957921f441d50af23654aa6c5e5eaf9b06aba7f0a19c18a538dc7ef291c5a1"},
+    {file = "PyYAML-6.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:afa17f5bc4d1b10afd4466fd3a44dc0e245382deca5b3c353d8b757f9e3ecb8d"},
+    {file = "PyYAML-6.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:dbad0e9d368bb989f4515da330b88a057617d16b6a8245084f1b05400f24609f"},
+    {file = "PyYAML-6.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:432557aa2c09802be39460360ddffd48156e30721f5e8d917f01d31694216782"},
+    {file = "PyYAML-6.0-cp311-cp311-win32.whl", hash = "sha256:bfaef573a63ba8923503d27530362590ff4f576c626d86a9fed95822a8255fd7"},
+    {file = "PyYAML-6.0-cp311-cp311-win_amd64.whl", hash = "sha256:01b45c0191e6d66c470b6cf1b9531a771a83c1c4208272ead47a3ae4f2f603bf"},
+    {file = "PyYAML-6.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:897b80890765f037df3403d22bab41627ca8811ae55e9a722fd0392850ec4d86"},
+    {file = "PyYAML-6.0-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:50602afada6d6cbfad699b0c7bb50d5ccffa7e46a3d738092afddc1f9758427f"},
+    {file = "PyYAML-6.0-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:48c346915c114f5fdb3ead70312bd042a953a8ce5c7106d5bfb1a5254e47da92"},
+    {file = "PyYAML-6.0-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:98c4d36e99714e55cfbaaee6dd5badbc9a1ec339ebfc3b1f52e293aee6bb71a4"},
+    {file = "PyYAML-6.0-cp36-cp36m-win32.whl", hash = "sha256:0283c35a6a9fbf047493e3a0ce8d79ef5030852c51e9d911a27badfde0605293"},
+    {file = "PyYAML-6.0-cp36-cp36m-win_amd64.whl", hash = "sha256:07751360502caac1c067a8132d150cf3d61339af5691fe9e87803040dbc5db57"},
+    {file = "PyYAML-6.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:819b3830a1543db06c4d4b865e70ded25be52a2e0631ccd2f6a47a2822f2fd7c"},
+    {file = "PyYAML-6.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:473f9edb243cb1935ab5a084eb238d842fb8f404ed2193a915d1784b5a6b5fc0"},
+    {file = "PyYAML-6.0-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0ce82d761c532fe4ec3f87fc45688bdd3a4c1dc5e0b4a19814b9009a29baefd4"},
+    {file = "PyYAML-6.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:231710d57adfd809ef5d34183b8ed1eeae3f76459c18fb4a0b373ad56bedcdd9"},
+    {file = "PyYAML-6.0-cp37-cp37m-win32.whl", hash = "sha256:c5687b8d43cf58545ade1fe3e055f70eac7a5a1a0bf42824308d868289a95737"},
+    {file = "PyYAML-6.0-cp37-cp37m-win_amd64.whl", hash = "sha256:d15a181d1ecd0d4270dc32edb46f7cb7733c7c508857278d3d378d14d606db2d"},
+    {file = "PyYAML-6.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:0b4624f379dab24d3725ffde76559cff63d9ec94e1736b556dacdfebe5ab6d4b"},
+    {file = "PyYAML-6.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:213c60cd50106436cc818accf5baa1aba61c0189ff610f64f4a3e8c6726218ba"},
+    {file = "PyYAML-6.0-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9fa600030013c4de8165339db93d182b9431076eb98eb40ee068700c9c813e34"},
+    {file = "PyYAML-6.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:277a0ef2981ca40581a47093e9e2d13b3f1fbbeffae064c1d21bfceba2030287"},
+    {file = "PyYAML-6.0-cp38-cp38-win32.whl", hash = "sha256:d4eccecf9adf6fbcc6861a38015c2a64f38b9d94838ac1810a9023a0609e1b78"},
+    {file = "PyYAML-6.0-cp38-cp38-win_amd64.whl", hash = "sha256:1e4747bc279b4f613a09eb64bba2ba602d8a6664c6ce6396a4d0cd413a50ce07"},
+    {file = "PyYAML-6.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:055d937d65826939cb044fc8c9b08889e8c743fdc6a32b33e2390f66013e449b"},
+    {file = "PyYAML-6.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:e61ceaab6f49fb8bdfaa0f92c4b57bcfbea54c09277b1b4f7ac376bfb7a7c174"},
+    {file = "PyYAML-6.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d67d839ede4ed1b28a4e8909735fc992a923cdb84e618544973d7dfc71540803"},
+    {file = "PyYAML-6.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cba8c411ef271aa037d7357a2bc8f9ee8b58b9965831d9e51baf703280dc73d3"},
+    {file = "PyYAML-6.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:40527857252b61eacd1d9af500c3337ba8deb8fc298940291486c465c8b46ec0"},
+    {file = "PyYAML-6.0-cp39-cp39-win32.whl", hash = "sha256:b5b9eccad747aabaaffbc6064800670f0c297e52c12754eb1d976c57e4f74dcb"},
+    {file = "PyYAML-6.0-cp39-cp39-win_amd64.whl", hash = "sha256:b3d267842bf12586ba6c734f89d1f5b871df0273157918b0ccefa29deb05c21c"},
+    {file = "PyYAML-6.0.tar.gz", hash = "sha256:68fb519c14306fec9720a2a5b45bc9f0c8d1b9c72adf45c37baedfcd949c35a2"},
+]
+
+[[package]]
+name = "regex"
+version = "2023.6.3"
+description = "Alternative regular expression module, to replace re."
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "regex-2023.6.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:824bf3ac11001849aec3fa1d69abcb67aac3e150a933963fb12bda5151fe1bfd"},
+    {file = "regex-2023.6.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:05ed27acdf4465c95826962528f9e8d41dbf9b1aa8531a387dee6ed215a3e9ef"},
+    {file = "regex-2023.6.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0b49c764f88a79160fa64f9a7b425620e87c9f46095ef9c9920542ab2495c8bc"},
+    {file = "regex-2023.6.3-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8e3f1316c2293e5469f8f09dc2d76efb6c3982d3da91ba95061a7e69489a14ef"},
+    {file = "regex-2023.6.3-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:43e1dd9d12df9004246bacb79a0e5886b3b6071b32e41f83b0acbf293f820ee8"},
+    {file = "regex-2023.6.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4959e8bcbfda5146477d21c3a8ad81b185cd252f3d0d6e4724a5ef11c012fb06"},
+    {file = "regex-2023.6.3-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:af4dd387354dc83a3bff67127a124c21116feb0d2ef536805c454721c5d7993d"},
+    {file = "regex-2023.6.3-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:2239d95d8e243658b8dbb36b12bd10c33ad6e6933a54d36ff053713f129aa536"},
+    {file = "regex-2023.6.3-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:890e5a11c97cf0d0c550eb661b937a1e45431ffa79803b942a057c4fb12a2da2"},
+    {file = "regex-2023.6.3-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:a8105e9af3b029f243ab11ad47c19b566482c150c754e4c717900a798806b222"},
+    {file = "regex-2023.6.3-cp310-cp310-musllinux_1_1_ppc64le.whl", hash = "sha256:25be746a8ec7bc7b082783216de8e9473803706723b3f6bef34b3d0ed03d57e2"},
+    {file = "regex-2023.6.3-cp310-cp310-musllinux_1_1_s390x.whl", hash = "sha256:3676f1dd082be28b1266c93f618ee07741b704ab7b68501a173ce7d8d0d0ca18"},
+    {file = "regex-2023.6.3-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:10cb847aeb1728412c666ab2e2000ba6f174f25b2bdc7292e7dd71b16db07568"},
+    {file = "regex-2023.6.3-cp310-cp310-win32.whl", hash = "sha256:dbbbfce33cd98f97f6bffb17801b0576e653f4fdb1d399b2ea89638bc8d08ae1"},
+    {file = "regex-2023.6.3-cp310-cp310-win_amd64.whl", hash = "sha256:c5f8037000eb21e4823aa485149f2299eb589f8d1fe4b448036d230c3f4e68e0"},
+    {file = "regex-2023.6.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:c123f662be8ec5ab4ea72ea300359023a5d1df095b7ead76fedcd8babbedf969"},
+    {file = "regex-2023.6.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:9edcbad1f8a407e450fbac88d89e04e0b99a08473f666a3f3de0fd292badb6aa"},
+    {file = "regex-2023.6.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dcba6dae7de533c876255317c11f3abe4907ba7d9aa15d13e3d9710d4315ec0e"},
+    {file = "regex-2023.6.3-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:29cdd471ebf9e0f2fb3cac165efedc3c58db841d83a518b082077e612d3ee5df"},
+    {file = "regex-2023.6.3-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:12b74fbbf6cbbf9dbce20eb9b5879469e97aeeaa874145517563cca4029db65c"},
+    {file = "regex-2023.6.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0c29ca1bd61b16b67be247be87390ef1d1ef702800f91fbd1991f5c4421ebae8"},
+    {file = "regex-2023.6.3-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d77f09bc4b55d4bf7cc5eba785d87001d6757b7c9eec237fe2af57aba1a071d9"},
+    {file = "regex-2023.6.3-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:ea353ecb6ab5f7e7d2f4372b1e779796ebd7b37352d290096978fea83c4dba0c"},
+    {file = "regex-2023.6.3-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:10590510780b7541969287512d1b43f19f965c2ece6c9b1c00fc367b29d8dce7"},
+    {file = "regex-2023.6.3-cp311-cp311-musllinux_1_1_ppc64le.whl", hash = "sha256:e2fbd6236aae3b7f9d514312cdb58e6494ee1c76a9948adde6eba33eb1c4264f"},
+    {file = "regex-2023.6.3-cp311-cp311-musllinux_1_1_s390x.whl", hash = "sha256:6b2675068c8b56f6bfd5a2bda55b8accbb96c02fd563704732fd1c95e2083461"},
+    {file = "regex-2023.6.3-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:74419d2b50ecb98360cfaa2974da8689cb3b45b9deff0dcf489c0d333bcc1477"},
+    {file = "regex-2023.6.3-cp311-cp311-win32.whl", hash = "sha256:fb5ec16523dc573a4b277663a2b5a364e2099902d3944c9419a40ebd56a118f9"},
+    {file = "regex-2023.6.3-cp311-cp311-win_amd64.whl", hash = "sha256:09e4a1a6acc39294a36b7338819b10baceb227f7f7dbbea0506d419b5a1dd8af"},
+    {file = "regex-2023.6.3-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:0654bca0cdf28a5956c83839162692725159f4cda8d63e0911a2c0dc76166525"},
+    {file = "regex-2023.6.3-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:463b6a3ceb5ca952e66550a4532cef94c9a0c80dc156c4cc343041951aec1697"},
+    {file = "regex-2023.6.3-cp36-cp36m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:87b2a5bb5e78ee0ad1de71c664d6eb536dc3947a46a69182a90f4410f5e3f7dd"},
+    {file = "regex-2023.6.3-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6343c6928282c1f6a9db41f5fd551662310e8774c0e5ebccb767002fcf663ca9"},
+    {file = "regex-2023.6.3-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b6192d5af2ccd2a38877bfef086d35e6659566a335b1492786ff254c168b1693"},
+    {file = "regex-2023.6.3-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:74390d18c75054947e4194019077e243c06fbb62e541d8817a0fa822ea310c14"},
+    {file = "regex-2023.6.3-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:742e19a90d9bb2f4a6cf2862b8b06dea5e09b96c9f2df1779e53432d7275331f"},
+    {file = "regex-2023.6.3-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:8abbc5d54ea0ee80e37fef009e3cec5dafd722ed3c829126253d3e22f3846f1e"},
+    {file = "regex-2023.6.3-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:c2b867c17a7a7ae44c43ebbeb1b5ff406b3e8d5b3e14662683e5e66e6cc868d3"},
+    {file = "regex-2023.6.3-cp36-cp36m-musllinux_1_1_ppc64le.whl", hash = "sha256:d831c2f8ff278179705ca59f7e8524069c1a989e716a1874d6d1aab6119d91d1"},
+    {file = "regex-2023.6.3-cp36-cp36m-musllinux_1_1_s390x.whl", hash = "sha256:ee2d1a9a253b1729bb2de27d41f696ae893507c7db224436abe83ee25356f5c1"},
+    {file = "regex-2023.6.3-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:61474f0b41fe1a80e8dfa70f70ea1e047387b7cd01c85ec88fa44f5d7561d787"},
+    {file = "regex-2023.6.3-cp36-cp36m-win32.whl", hash = "sha256:0b71e63226e393b534105fcbdd8740410dc6b0854c2bfa39bbda6b0d40e59a54"},
+    {file = "regex-2023.6.3-cp36-cp36m-win_amd64.whl", hash = "sha256:bbb02fd4462f37060122e5acacec78e49c0fbb303c30dd49c7f493cf21fc5b27"},
+    {file = "regex-2023.6.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:b862c2b9d5ae38a68b92e215b93f98d4c5e9454fa36aae4450f61dd33ff48487"},
+    {file = "regex-2023.6.3-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:976d7a304b59ede34ca2921305b57356694f9e6879db323fd90a80f865d355a3"},
+    {file = "regex-2023.6.3-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:83320a09188e0e6c39088355d423aa9d056ad57a0b6c6381b300ec1a04ec3d16"},
+    {file = "regex-2023.6.3-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9427a399501818a7564f8c90eced1e9e20709ece36be701f394ada99890ea4b3"},
+    {file = "regex-2023.6.3-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7178bbc1b2ec40eaca599d13c092079bf529679bf0371c602edaa555e10b41c3"},
+    {file = "regex-2023.6.3-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:837328d14cde912af625d5f303ec29f7e28cdab588674897baafaf505341f2fc"},
+    {file = "regex-2023.6.3-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:2d44dc13229905ae96dd2ae2dd7cebf824ee92bc52e8cf03dcead37d926da019"},
+    {file = "regex-2023.6.3-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:d54af539295392611e7efbe94e827311eb8b29668e2b3f4cadcfe6f46df9c777"},
+    {file = "regex-2023.6.3-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:7117d10690c38a622e54c432dfbbd3cbd92f09401d622902c32f6d377e2300ee"},
+    {file = "regex-2023.6.3-cp37-cp37m-musllinux_1_1_ppc64le.whl", hash = "sha256:bb60b503ec8a6e4e3e03a681072fa3a5adcbfa5479fa2d898ae2b4a8e24c4591"},
+    {file = "regex-2023.6.3-cp37-cp37m-musllinux_1_1_s390x.whl", hash = "sha256:65ba8603753cec91c71de423a943ba506363b0e5c3fdb913ef8f9caa14b2c7e0"},
+    {file = "regex-2023.6.3-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:271f0bdba3c70b58e6f500b205d10a36fb4b58bd06ac61381b68de66442efddb"},
+    {file = "regex-2023.6.3-cp37-cp37m-win32.whl", hash = "sha256:9beb322958aaca059f34975b0df135181f2e5d7a13b84d3e0e45434749cb20f7"},
+    {file = "regex-2023.6.3-cp37-cp37m-win_amd64.whl", hash = "sha256:fea75c3710d4f31389eed3c02f62d0b66a9da282521075061ce875eb5300cf23"},
+    {file = "regex-2023.6.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:8f56fcb7ff7bf7404becdfc60b1e81a6d0561807051fd2f1860b0d0348156a07"},
+    {file = "regex-2023.6.3-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:d2da3abc88711bce7557412310dfa50327d5769a31d1c894b58eb256459dc289"},
+    {file = "regex-2023.6.3-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a99b50300df5add73d307cf66abea093304a07eb017bce94f01e795090dea87c"},
+    {file = "regex-2023.6.3-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5708089ed5b40a7b2dc561e0c8baa9535b77771b64a8330b684823cfd5116036"},
+    {file = "regex-2023.6.3-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:687ea9d78a4b1cf82f8479cab23678aff723108df3edeac098e5b2498879f4a7"},
+    {file = "regex-2023.6.3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4d3850beab9f527f06ccc94b446c864059c57651b3f911fddb8d9d3ec1d1b25d"},
+    {file = "regex-2023.6.3-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e8915cc96abeb8983cea1df3c939e3c6e1ac778340c17732eb63bb96247b91d2"},
+    {file = "regex-2023.6.3-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:841d6e0e5663d4c7b4c8099c9997be748677d46cbf43f9f471150e560791f7ff"},
+    {file = "regex-2023.6.3-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:9edce5281f965cf135e19840f4d93d55b3835122aa76ccacfd389e880ba4cf82"},
+    {file = "regex-2023.6.3-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:b956231ebdc45f5b7a2e1f90f66a12be9610ce775fe1b1d50414aac1e9206c06"},
+    {file = "regex-2023.6.3-cp38-cp38-musllinux_1_1_ppc64le.whl", hash = "sha256:36efeba71c6539d23c4643be88295ce8c82c88bbd7c65e8a24081d2ca123da3f"},
+    {file = "regex-2023.6.3-cp38-cp38-musllinux_1_1_s390x.whl", hash = "sha256:cf67ca618b4fd34aee78740bea954d7c69fdda419eb208c2c0c7060bb822d747"},
+    {file = "regex-2023.6.3-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:b4598b1897837067a57b08147a68ac026c1e73b31ef6e36deeeb1fa60b2933c9"},
+    {file = "regex-2023.6.3-cp38-cp38-win32.whl", hash = "sha256:f415f802fbcafed5dcc694c13b1292f07fe0befdb94aa8a52905bd115ff41e88"},
+    {file = "regex-2023.6.3-cp38-cp38-win_amd64.whl", hash = "sha256:d4f03bb71d482f979bda92e1427f3ec9b220e62a7dd337af0aa6b47bf4498f72"},
+    {file = "regex-2023.6.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:ccf91346b7bd20c790310c4147eee6ed495a54ddb6737162a36ce9dbef3e4751"},
+    {file = "regex-2023.6.3-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:b28f5024a3a041009eb4c333863d7894d191215b39576535c6734cd88b0fcb68"},
+    {file = "regex-2023.6.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e0bb18053dfcfed432cc3ac632b5e5e5c5b7e55fb3f8090e867bfd9b054dbcbf"},
+    {file = "regex-2023.6.3-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9a5bfb3004f2144a084a16ce19ca56b8ac46e6fd0651f54269fc9e230edb5e4a"},
+    {file = "regex-2023.6.3-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5c6b48d0fa50d8f4df3daf451be7f9689c2bde1a52b1225c5926e3f54b6a9ed1"},
+    {file = "regex-2023.6.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:051da80e6eeb6e239e394ae60704d2b566aa6a7aed6f2890a7967307267a5dc6"},
+    {file = "regex-2023.6.3-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a4c3b7fa4cdaa69268748665a1a6ff70c014d39bb69c50fda64b396c9116cf77"},
+    {file = "regex-2023.6.3-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:457b6cce21bee41ac292d6753d5e94dcbc5c9e3e3a834da285b0bde7aa4a11e9"},
+    {file = "regex-2023.6.3-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:aad51907d74fc183033ad796dd4c2e080d1adcc4fd3c0fd4fd499f30c03011cd"},
+    {file = "regex-2023.6.3-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:0385e73da22363778ef2324950e08b689abdf0b108a7d8decb403ad7f5191938"},
+    {file = "regex-2023.6.3-cp39-cp39-musllinux_1_1_ppc64le.whl", hash = "sha256:c6a57b742133830eec44d9b2290daf5cbe0a2f1d6acee1b3c7b1c7b2f3606df7"},
+    {file = "regex-2023.6.3-cp39-cp39-musllinux_1_1_s390x.whl", hash = "sha256:3e5219bf9e75993d73ab3d25985c857c77e614525fac9ae02b1bebd92f7cecac"},
+    {file = "regex-2023.6.3-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:e5087a3c59eef624a4591ef9eaa6e9a8d8a94c779dade95d27c0bc24650261cd"},
+    {file = "regex-2023.6.3-cp39-cp39-win32.whl", hash = "sha256:20326216cc2afe69b6e98528160b225d72f85ab080cbdf0b11528cbbaba2248f"},
+    {file = "regex-2023.6.3-cp39-cp39-win_amd64.whl", hash = "sha256:bdff5eab10e59cf26bc479f565e25ed71a7d041d1ded04ccf9aee1d9f208487a"},
+    {file = "regex-2023.6.3.tar.gz", hash = "sha256:72d1a25bf36d2050ceb35b517afe13864865268dfb45910e2e17a84be6cbfeb0"},
+]
+
+[[package]]
+name = "requests"
+version = "2.31.0"
+description = "Python HTTP for Humans."
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "requests-2.31.0-py3-none-any.whl", hash = "sha256:58cd2187c01e70e6e26505bca751777aa9f2ee0b7f4300988b709f44e013003f"},
+    {file = "requests-2.31.0.tar.gz", hash = "sha256:942c5a758f98d790eaed1a29cb6eefc7ffb0d1cf7af05c3d2791656dbd6ad1e1"},
+]
+
+[package.dependencies]
+certifi = ">=2017.4.17"
+charset-normalizer = ">=2,<4"
+idna = ">=2.5,<4"
+urllib3 = ">=1.21.1,<3"
+
+[package.extras]
+socks = ["PySocks (>=1.5.6,!=1.5.7)"]
+use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
+
+[[package]]
+name = "responses"
+version = "0.23.1"
+description = "A utility library for mocking out the `requests` Python library."
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "responses-0.23.1-py3-none-any.whl", hash = "sha256:8a3a5915713483bf353b6f4079ba8b2a29029d1d1090a503c70b0dc5d9d0c7bd"},
+    {file = "responses-0.23.1.tar.gz", hash = "sha256:c4d9aa9fc888188f0c673eff79a8dadbe2e75b7fe879dc80a221a06e0a68138f"},
+]
+
+[package.dependencies]
+pyyaml = "*"
+requests = ">=2.22.0,<3.0"
+types-PyYAML = "*"
+urllib3 = ">=1.25.10"
+
+[package.extras]
+tests = ["coverage (>=6.0.0)", "flake8", "mypy", "pytest (>=7.0.0)", "pytest-asyncio", "pytest-cov", "pytest-httpserver", "tomli", "tomli-w", "types-requests"]
+
+[[package]]
+name = "rfc3339-validator"
+version = "0.1.4"
+description = "A pure python RFC3339 validator"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+files = [
+    {file = "rfc3339_validator-0.1.4-py2.py3-none-any.whl", hash = "sha256:24f6ec1eda14ef823da9e36ec7113124b39c04d50a4d3d3a3c2859577e7791fa"},
+    {file = "rfc3339_validator-0.1.4.tar.gz", hash = "sha256:138a2abdf93304ad60530167e51d2dfb9549521a836871b88d7f4695d0022f6b"},
+]
+
+[package.dependencies]
+six = "*"
+
+[[package]]
+name = "rsa"
+version = "4.9"
+description = "Pure-Python RSA implementation"
+category = "dev"
+optional = false
+python-versions = ">=3.6,<4"
+files = [
+    {file = "rsa-4.9-py3-none-any.whl", hash = "sha256:90260d9058e514786967344d0ef75fa8727eed8a7d2e43ce9f4bcf1b536174f7"},
+    {file = "rsa-4.9.tar.gz", hash = "sha256:e38464a49c6c85d7f1351b0126661487a7e0a14a50f1675ec50eb34d4f20ef21"},
+]
+
+[package.dependencies]
+pyasn1 = ">=0.1.3"
 
 [[package]]
 name = "s3fs"
@@ -1739,6 +2743,22 @@ botocore = ">=1.12.36,<2.0a.0"
 crt = ["botocore[crt] (>=1.20.29,<2.0a.0)"]
 
 [[package]]
+name = "sarif-om"
+version = "1.0.4"
+description = "Classes implementing the SARIF 2.1.0 object model."
+category = "dev"
+optional = false
+python-versions = ">= 2.7"
+files = [
+    {file = "sarif_om-1.0.4-py3-none-any.whl", hash = "sha256:539ef47a662329b1c8502388ad92457425e95dc0aaaf995fe46f4984c4771911"},
+    {file = "sarif_om-1.0.4.tar.gz", hash = "sha256:cd5f416b3083e00d402a92e449a7ff67af46f11241073eea0461802a3b5aef98"},
+]
+
+[package.dependencies]
+attrs = "*"
+pbr = "*"
+
+[[package]]
 name = "scipy"
 version = "1.10.1"
 description = "Fundamental algorithms for scientific computing in Python"
@@ -1776,6 +2796,23 @@ numpy = ">=1.19.5,<1.27.0"
 dev = ["click", "doit (>=0.36.0)", "flake8", "mypy", "pycodestyle", "pydevtool", "rich-click", "typing_extensions"]
 doc = ["matplotlib (>2)", "numpydoc", "pydata-sphinx-theme (==0.9.0)", "sphinx (!=4.1.0)", "sphinx-design (>=0.2.0)"]
 test = ["asv", "gmpy2", "mpmath", "pooch", "pytest", "pytest-cov", "pytest-timeout", "pytest-xdist", "scikit-umfpack", "threadpoolctl"]
+
+[[package]]
+name = "setuptools"
+version = "68.0.0"
+description = "Easily download, build, install, upgrade, and uninstall Python packages"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "setuptools-68.0.0-py3-none-any.whl", hash = "sha256:11e52c67415a381d10d6b462ced9cfb97066179f0e871399e006c4ab101fc85f"},
+    {file = "setuptools-68.0.0.tar.gz", hash = "sha256:baf1fdb41c6da4cd2eae722e135500da913332ab3f2f5c7d33af9b492acb5235"},
+]
+
+[package.extras]
+docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-hoverxref (<2)", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (==0.8.3)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
+testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8-2020", "ini2toml[lite] (>=0.9)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pip (>=19.1)", "pip-run (>=8.8)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-mypy (>=0.9.1)", "pytest-perf", "pytest-ruff", "pytest-timeout", "pytest-xdist", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
+testing-integration = ["build[virtualenv]", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
 
 [[package]]
 name = "six"
@@ -1868,6 +2905,40 @@ pymysql = ["pymysql"]
 sqlcipher = ["sqlcipher3-binary"]
 
 [[package]]
+name = "sshpubkeys"
+version = "3.3.1"
+description = "SSH public key parser"
+category = "dev"
+optional = false
+python-versions = ">=3"
+files = [
+    {file = "sshpubkeys-3.3.1-py2.py3-none-any.whl", hash = "sha256:946f76b8fe86704b0e7c56a00d80294e39bc2305999844f079a217885060b1ac"},
+    {file = "sshpubkeys-3.3.1.tar.gz", hash = "sha256:3020ed4f8c846849299370fbe98ff4157b0ccc1accec105e07cfa9ae4bb55064"},
+]
+
+[package.dependencies]
+cryptography = ">=2.1.4"
+ecdsa = ">=0.13"
+
+[package.extras]
+dev = ["twine", "wheel", "yapf"]
+
+[[package]]
+name = "sympy"
+version = "1.12"
+description = "Computer algebra system (CAS) in Python"
+category = "dev"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "sympy-1.12-py3-none-any.whl", hash = "sha256:c3588cd4295d0c0f603d0f2ae780587e64e2efeedb3521e46b9bb1d08d184fa5"},
+    {file = "sympy-1.12.tar.gz", hash = "sha256:ebf595c8dac3e0fdc4152c51878b498396ec7f30e7a914d6071e674d49420fb8"},
+]
+
+[package.dependencies]
+mpmath = ">=0.19"
+
+[[package]]
 name = "tomli"
 version = "2.0.1"
 description = "A lil' TOML parser"
@@ -1889,6 +2960,18 @@ python-versions = "*"
 files = [
     {file = "types-pytz-2023.3.0.0.tar.gz", hash = "sha256:ecdc70d543aaf3616a7e48631543a884f74205f284cefd6649ddf44c6a820aac"},
     {file = "types_pytz-2023.3.0.0-py3-none-any.whl", hash = "sha256:4fc2a7fbbc315f0b6630e0b899fd6c743705abe1094d007b0e612d10da15e0f3"},
+]
+
+[[package]]
+name = "types-pyyaml"
+version = "6.0.12.10"
+description = "Typing stubs for PyYAML"
+category = "dev"
+optional = false
+python-versions = "*"
+files = [
+    {file = "types-PyYAML-6.0.12.10.tar.gz", hash = "sha256:ebab3d0700b946553724ae6ca636ea932c1b0868701d4af121630e78d695fc97"},
+    {file = "types_PyYAML-6.0.12.10-py3-none-any.whl", hash = "sha256:662fa444963eff9b68120d70cda1af5a5f2aa57900003c2006d7626450eaae5f"},
 ]
 
 [[package]]
@@ -1931,6 +3014,23 @@ files = [
 brotli = ["brotli (>=1.0.9)", "brotlicffi (>=0.8.0)", "brotlipy (>=0.6.0)"]
 secure = ["certifi", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "ipaddress", "pyOpenSSL (>=0.14)", "urllib3-secure-extra"]
 socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
+
+[[package]]
+name = "websocket-client"
+version = "1.6.1"
+description = "WebSocket client for Python with low level API options"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "websocket-client-1.6.1.tar.gz", hash = "sha256:c951af98631d24f8df89ab1019fc365f2227c0892f12fd150e935607c79dd0dd"},
+    {file = "websocket_client-1.6.1-py3-none-any.whl", hash = "sha256:f1f9f2ad5291f0225a49efad77abf9e700b6fef553900623060dad6e26503b9d"},
+]
+
+[package.extras]
+docs = ["Sphinx (>=3.4)", "sphinx-rtd-theme (>=0.5)"]
+optional = ["python-socks", "wsaccel"]
+test = ["websockets"]
 
 [[package]]
 name = "werkzeug"
@@ -2061,6 +3161,18 @@ parallel = ["dask[complete]"]
 viz = ["matplotlib", "nc-time-axis", "seaborn"]
 
 [[package]]
+name = "xmltodict"
+version = "0.13.0"
+description = "Makes working with XML feel like you are working with JSON"
+category = "dev"
+optional = false
+python-versions = ">=3.4"
+files = [
+    {file = "xmltodict-0.13.0-py2.py3-none-any.whl", hash = "sha256:aa89e8fd76320154a40d19a0df04a4695fb9dc5ba977cbb68ab3e4eb225e7852"},
+    {file = "xmltodict-0.13.0.tar.gz", hash = "sha256:341595a488e3e01a85a9d8911d8912fd922ede5fecc4dce437eb4b6c8d037e56"},
+]
+
+[[package]]
 name = "yarl"
 version = "1.9.2"
 description = "Yet another URL library"
@@ -2188,4 +3300,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.9"
-content-hash = "4a0af860b72f447f37742bfb3d3772b33d6cef742bc7e09d6566f2c75b387a4e"
+content-hash = "e6d714300b29bfce7fcd451f8205118887ddc5239a9939b4bd18f6ea7dd16b9a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ isort = "^5.10.1"
 [tool.poetry.group.dev.dependencies]
 python-dotenv = "^1.0.0"
 pandas-stubs = "^2.0.2.230605"
+moto = {extras = ["server"], version = "^4.1.12"}
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -85,7 +85,6 @@ def session(engine):
         s.rollback()
 
 
-# FIXME: Replace diag_dataset with this fixture
 @pytest.fixture(scope="class")
 def test_dataset():
     def factory(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,4 @@
 import os
-from pathlib import Path
 from typing import Optional
 
 import alembic.command
@@ -111,53 +110,6 @@ def app(diag_zarr_file, test_db):
 def client(app):
     with app.test_client() as c:
         yield c
-
-
-@pytest.fixture
-def diag_file(app, tmp_path):
-    def factory(
-        variable: str,
-        loop: str,
-        init_time: str,
-        model: Optional[str] = None,
-        system: Optional[str] = None,
-        domain: Optional[str] = None,
-        frequency: Optional[str] = None,
-        background: Optional[str] = None,
-    ) -> Path:
-        filename = f"ncdiag_conv_{variable}_{loop}.{init_time}"
-        if background:
-            filename += f".{background}"
-        filename += ".nc4"
-
-        if frequency:
-            filename = f"{frequency}_{filename}"
-        if domain:
-            filename = f"{domain}_{filename}"
-        if system:
-            filename = f"{system}_{filename}"
-        if model:
-            filename = f"{model}_{filename}"
-
-        ds = xr.Dataset(
-            {
-                "Forecast_adjusted": (["nobs"], np.zeros((3,))),
-                "Forecast_unadjusted": (["nobs"], np.zeros((3,))),
-                "Obs_Minus_Forecast_adjusted": (["nobs"], np.zeros((3,))),
-                "Obs_Minus_Forecast_unadjusted": (["nobs"], np.zeros((3,))),
-                "Observation": (["nobs"], np.zeros((3,))),
-                "Analysis_Use_Flag": (["nobs"], np.array([1, -1, 1], dtype=np.int8)),
-                "Latitude": (["nobs"], np.array([22, 23, 25], dtype=np.float64)),
-                "Longitude": (["nobs"], np.array([90, 91, 200], dtype=np.float64)),
-            }
-        )
-
-        diag_file = tmp_path / filename
-        ds.to_netcdf(diag_file)
-
-        return diag_file
-
-    return factory
 
 
 # FIXME: Replace diag_dataset with this fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,34 +30,6 @@ test_db_pass = os.environ.get("TEST_DB_PASS", "postgres")
 test_db_host = os.environ.get("TEST_DB_HOST", "localhost:5432")
 
 
-def pytest_addoption(parser):
-    parser.addoption(
-        "--runaws",
-        action="store_true",
-        default=False,
-        help="run tests that require authentication to AWS",
-    )
-
-
-def pytest_configure(config):
-    config.addinivalue_line(
-        "markers", "aws: mark test as requiring an authenticated connection to AWS"
-    )
-
-
-def pytest_collection_modifyitems(config, items):
-    if config.getoption("--runaws"):
-        # If --runaws is set, there's no need to modify any of the tests
-        # to mark them skipped.
-        return
-
-    # Mark any test with the aws mark as skipped because --runaws is off
-    skip_aws = pytest.mark.skip(reason="use --runaws to run")
-    for item in items:
-        if "aws" in item.keywords:
-            item.add_marker(skip_aws)
-
-
 @pytest.fixture(scope="session")
 def db_name():
     return "test_unified_graphics"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,8 +13,6 @@ import sqlalchemy
 import xarray as xr
 from sqlalchemy.orm import Session
 
-from unified_graphics import create_app
-
 try:
     from dotenv import load_dotenv
 
@@ -87,31 +85,6 @@ def session(engine):
         s.rollback()
 
 
-@pytest.fixture
-def diag_zarr_file(tmp_path):
-    return str(tmp_path / "test_diag.zarr")
-
-
-@pytest.fixture
-def app(diag_zarr_file, test_db):
-    _app = create_app(
-        {
-            "SQLALCHEMY_DATABASE_URI": test_db,
-            "DIAG_ZARR": diag_zarr_file,
-        }
-    )
-
-    _app.testing = True
-
-    yield _app
-
-
-@pytest.fixture
-def client(app):
-    with app.test_client() as c:
-        yield c
-
-
 # FIXME: Replace diag_dataset with this fixture
 @pytest.fixture(scope="class")
 def test_dataset():
@@ -168,113 +141,5 @@ def test_dataset():
                 "background": background,
             },
         )
-
-    return factory
-
-
-@pytest.fixture(scope="session")
-def diag_dataset():
-    def factory(
-        variable: str,
-        initialization_time: str,
-        loop: str,
-        model: Optional[str] = None,
-        system: Optional[str] = None,
-        domain: Optional[str] = None,
-        frequency: Optional[str] = None,
-        background: Optional[str] = None,
-        data: Optional[xr.Dataset] = None,
-        **kwargs,
-    ):
-        dims = ["nobs", *kwargs.keys()]
-        shape = [3, *map(len, kwargs.values())]
-        variables = [
-            "observation",
-            "forecast_adjusted",
-            "obs_minus_forecast_adjusted",
-            "forecast_unadjusted",
-            "obs_minus_forecast_unadjusted",
-        ]
-
-        if data:
-            ds = data
-            ds.attrs.update(
-                name=variable, loop=loop, initialization_time=initialization_time
-            )
-        else:
-            ds = xr.Dataset(
-                {var: (dims, np.zeros(shape)) for var in variables},
-                coords=dict(
-                    longitude=(["nobs"], np.array([90, 91, -160], dtype=np.float64)),
-                    latitude=(["nobs"], np.array([22, 23, 25], dtype=np.float64)),
-                    is_used=(["nobs"], np.array([1, 0, 1], dtype=np.int8)),
-                    **kwargs,
-                ),
-                attrs={
-                    "name": variable,
-                    "loop": loop,
-                    "initialization_time": initialization_time,
-                    "model": model or "Unknown",
-                    "system": system or "Unknown",
-                    "domain": domain or "Unknown",
-                    "frequency": frequency or "Unknown",
-                    "background": background or "Unknown",
-                },
-            )
-
-        return ds
-
-    return factory
-
-
-@pytest.fixture
-def diag_zarr(diag_zarr_file, diag_dataset):
-    def factory(
-        variables: list[str],
-        initialization_time: str,
-        loop: str,
-        model: Optional[str] = "RTMA",
-        system: Optional[str] = "WCOSS",
-        domain: Optional[str] = "CONUS",
-        frequency: Optional[str] = "REALTIME",
-        background: Optional[str] = "HRRR",
-        zarr_file: str = "",
-        data: Optional[xr.Dataset] = None,
-    ):
-        if not zarr_file:
-            zarr_file = diag_zarr_file
-
-        if data:
-            group = (
-                f"/{data.model}/{data.system}/{data.domain}/{data.background}"
-                f"/{data.frequency}/{data.attrs['name']}/{initialization_time}/{loop}"
-            )
-            data.to_zarr(zarr_file, group=group, consolidated=False)
-            return zarr_file
-
-        for variable in variables:
-            coords = {"component": ["u", "v"]} if variable == "uv" else {}
-
-            ds = diag_dataset(
-                variable,
-                initialization_time,
-                loop,
-                model,
-                system,
-                domain,
-                frequency,
-                background,
-                **coords,
-            )
-            try:
-                group = (
-                    f"/{ds.model}/{ds.system}/{ds.domain}/{ds.background}"
-                    f"/{ds.frequency}/{variable}/{initialization_time}/{loop}"
-                )
-                ds.to_zarr(zarr_file, group=group, consolidated=False)
-            except Exception as e:
-                raise e
-
-        return zarr_file
 
     return factory

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -113,7 +113,7 @@ def client(app):
 
 
 # FIXME: Replace diag_dataset with this fixture
-@pytest.fixture
+@pytest.fixture(scope="class")
 def test_dataset():
     def factory(
         *,

--- a/tests/etl/test_extract.py
+++ b/tests/etl/test_extract.py
@@ -1,8 +1,69 @@
+from typing import Optional
+
 import numpy as np
 import pytest
 import xarray as xr
 
 from unified_graphics.etl import diag
+
+
+@pytest.fixture(scope="module")
+def input_data():
+    def _input_data(
+        *,
+        Forecast_adjusted,
+        Forecast_unadjusted,
+        Observation,
+        Analysis_Use_Flag,
+        Latitude,
+        Longitude,
+    ):
+        return xr.Dataset(
+            {
+                "Forecast_adjusted": (["nobs"], Forecast_adjusted),
+                "Forecast_unadjusted": (["nobs"], Forecast_unadjusted),
+                "Obs_Minus_Forecast_adjusted": (
+                    ["nobs"],
+                    Observation - Forecast_adjusted,
+                ),
+                "Obs_Minus_Forecast_unadjusted": (
+                    ["nobs"],
+                    Observation - Forecast_unadjusted,
+                ),
+                "Observation": (["nobs"], Observation),
+                "Analysis_Use_Flag": (["nobs"], Analysis_Use_Flag),
+                "Latitude": (["nobs"], Latitude),
+                "Longitude": (["nobs"], Longitude),
+            }
+        )
+
+    return _input_data
+
+
+@pytest.fixture(scope="class")
+def netcdf_path(tmp_path_factory):
+    def _netcdf_path(
+        variable: str,
+        loop: str,
+        init_time: str,
+        model: Optional[str] = None,
+        system: Optional[str] = None,
+        domain: Optional[str] = None,
+        frequency: Optional[str] = None,
+        background: Optional[str] = None,
+    ):
+        path = tmp_path_factory.mktemp("diag_netcdf")
+
+        filename = f"ncdiag_conv_{variable}_{loop}.{init_time}"
+        if background:
+            filename += "." + background
+        filename += ".nc4"
+
+        prefix = "_".join(filter(None, (model, system, domain, frequency)))
+
+        return path / "_".join(filter(None, (prefix, filename)))
+
+    return _netcdf_path
 
 
 @pytest.mark.parametrize(
@@ -167,50 +228,83 @@ def test_get_data_array_vector(variable):
 
 
 @pytest.mark.parametrize(
-    "variable,loop,init_time,model,system,domain,frequency,background,coords",
+    "variable,loop,init_time,model,system,domain,frequency,background",
     [
-        ("ps", "anl", "2022050514", None, None, None, None, None, {}),
-        ("q", "anl", "2022050514", "RTMA", "WCOSS", "CONUS", "REALTIME", "HRRR", {}),
-        ("t", "anl", "2022050514", "RTMA", "WCOSS", "CONUS", "REALTIME", "HRRR", {}),
+        ("q", "anl", "2022050514", None, None, None, None, None),
+        ("q", "anl", "2022050514", "RTMA", "WCOSS", "CONUS", "REALTIME", "HRRR"),
     ],
+    scope="class",
 )
-def test_load(
-    variable,
-    loop,
-    init_time,
-    model,
-    system,
-    domain,
-    frequency,
-    background,
-    coords,
-    diag_file,
-    diag_dataset,
-):
+class TestLoad:
     """diag.load should return datasets for observations, forecasts, and results"""
 
-    test_file = diag_file(
-        variable, loop, init_time, model, system, domain, frequency, background
-    )
-    expected_init_time = (
-        f"{init_time[:4]}-{init_time[4:6]}-{init_time[6:8]}T{init_time[-2:]}:00"
-    )
-    expected = diag_dataset(
+    @pytest.fixture(scope="class")
+    def test_file(
+        self,
         variable,
-        expected_init_time,
         loop,
+        init_time,
         model,
         system,
         domain,
         frequency,
         background,
-        **coords,
-    )
+        input_data,
+        netcdf_path,
+    ):
+        ds = input_data(
+            Forecast_adjusted=np.array([0, 1]),
+            Forecast_unadjusted=np.array([0, 1]),
+            Observation=np.array([1, 0]),
+            Analysis_Use_Flag=np.array([1, -1]),
+            Latitude=np.array([22, 23]),
+            Longitude=np.array([90, 91]),
+        )
 
-    result = diag.load(test_file)
+        path = netcdf_path(
+            variable, loop, init_time, model, system, domain, frequency, background
+        )
 
-    xr.testing.assert_equal(result, expected)
-    assert result.attrs == expected.attrs
+        ds.to_netcdf(path)
+
+        return path
+
+    @pytest.fixture
+    def expected(
+        self,
+        variable,
+        loop,
+        init_time,
+        model,
+        system,
+        domain,
+        frequency,
+        background,
+        test_dataset,
+    ):
+        expected_init_time = (
+            f"{init_time[:4]}-{init_time[4:6]}-{init_time[6:8]}T{init_time[-2:]}:00"
+        )
+        return test_dataset(
+            model=model or "Unknown",
+            system=system or "Unknown",
+            domain=domain or "Unknown",
+            background=background or "Unknown",
+            frequency=frequency or "Unknown",
+            initialization_time=expected_init_time,
+            variable=variable,
+            loop=loop,
+        )
+
+    @pytest.fixture(scope="class")
+    def result(self, test_file):
+        return diag.load(test_file)
+
+    def test_datasets(self, result, expected):
+        xr.testing.assert_equal(result, expected)
+
+    def test_attributes(self, result, expected):
+        assert result.attrs == expected.attrs
 
 
 def test_no_forecast_scalar(diag_dataset, tmp_path):

--- a/tests/etl/test_extract.py
+++ b/tests/etl/test_extract.py
@@ -307,49 +307,85 @@ class TestLoad:
         assert result.attrs == expected.attrs
 
 
-def test_no_forecast_scalar(diag_dataset, tmp_path):
-    model = "RTMA"
-    system = "WCOSS"
-    domain = "CONUS"
-    frequency = "REALTIME"
-    background = "HRRR"
-    init_time = "202303171400"
-    expected_init_time = "2023-03-17T14:00"
-    variable = "ps"
-    loop = "ges"
+class TestNoForecastScalar:
+    @pytest.fixture(scope="class")
+    def obs(self):
+        return np.array([1.0, 0.0])
 
-    # FIXME: This test data should be created by a fixture
-    filename = (
-        f"{model}_{system}_{domain}_{frequency}_"
-        f"ncdiag_conv_{variable}_{loop}.{init_time}.{background}.nc4"
-    )
-    ds = xr.Dataset(
-        {
-            "Obs_Minus_Forecast_adjusted": (["nobs"], np.zeros((3,))),
-            "Obs_Minus_Forecast_unadjusted": (["nobs"], np.zeros((3,))),
-            "Observation": (["nobs"], np.zeros((3,))),
-            "Analysis_Use_Flag": (["nobs"], np.array([1, -1, 1], dtype=np.int8)),
-            "Latitude": (["nobs"], np.array([22, 23, 25], dtype=np.float64)),
-            "Longitude": (["nobs"], np.array([90, 91, 200], dtype=np.float64)),
-        }
-    )
-    ds.to_netcdf(tmp_path / filename)
+    @pytest.fixture(scope="class")
+    def fcst_adj(self):
+        return np.array([0.1, 1.1])
 
-    expected = diag_dataset(
-        variable,
-        expected_init_time,
-        loop,
-        model,
-        system,
-        domain,
-        frequency,
-        background,
-    )
+    @pytest.fixture(scope="class")
+    def fcst_un(self):
+        return np.array([0.0, 1.0])
 
-    result = diag.load(tmp_path / filename)
+    @pytest.fixture(scope="class")
+    def used(self):
+        return np.array([1.0, -1.0])
 
-    xr.testing.assert_equal(result, expected)
-    assert result.attrs == expected.attrs
+    @pytest.fixture(scope="class")
+    def lng(self):
+        return np.array([90.0, 91.0])
+
+    @pytest.fixture(scope="class")
+    def lat(self):
+        return np.array([22.0, 23.0])
+
+    @pytest.fixture(scope="class")
+    def test_file(self, netcdf_path, obs, fcst_adj, fcst_un, used, lng, lat):
+        path = netcdf_path(
+            variable="ps",
+            loop="ges",
+            init_time="202303171400",
+            model="RTMA",
+            system="WCOSS",
+            domain="CONUS",
+            frequency="REALTIME",
+            background="HRRR",
+        )
+
+        ds = xr.Dataset(
+            {
+                "Obs_Minus_Forecast_adjusted": (["nobs"], obs - fcst_adj),
+                "Obs_Minus_Forecast_unadjusted": (["nobs"], obs - fcst_un),
+                "Observation": (["nobs"], obs),
+                "Analysis_Use_Flag": (["nobs"], used),
+                "Latitude": (["nobs"], lat),
+                "Longitude": (["nobs"], lng),
+            }
+        )
+        ds.to_netcdf(path)
+
+        return path
+
+    @pytest.fixture
+    def result(self, test_file):
+        return diag.load(test_file)
+
+    def test_forecast_adjusted(self, result, fcst_adj, lng, lat, used):
+        expected = xr.DataArray(
+            fcst_adj,
+            coords={
+                "longitude": ("nobs", lng),
+                "latitude": ("nobs", lat),
+                "is_used": ("nobs", used == 1),
+            },
+            dims=["nobs"],
+        )
+        xr.testing.assert_allclose(result["forecast_adjusted"], expected)
+
+    def test_forecast_unadjusted(self, result, fcst_un, lng, lat, used):
+        expected = xr.DataArray(
+            fcst_un,
+            coords={
+                "longitude": ("nobs", lng),
+                "latitude": ("nobs", lat),
+                "is_used": ("nobs", used == 1),
+            },
+            dims=["nobs"],
+        )
+        xr.testing.assert_equal(result["forecast_unadjusted"], expected)
 
 
 def test_no_forecast_vector(diag_dataset, tmp_path):

--- a/tests/etl/test_save.py
+++ b/tests/etl/test_save.py
@@ -48,17 +48,17 @@ def dataset_to_table(dataset: xr.Dataset) -> pd.DataFrame:
 
 class TestSaveNew:
     @pytest.fixture(scope="class", autouse=True)
-    def dataset(self, model, diag_dataset, session, zarr_file):
+    def dataset(self, model, test_dataset, session, zarr_file):
         (mdl, system, domain, background, frequency) = model
-        ps = diag_dataset(
-            "ps",
-            "2022-05-05T14:00",
-            "anl",
-            mdl,
-            system,
-            domain,
-            frequency,
-            background,
+        ps = test_dataset(
+            variable="ps",
+            initialization_time="2022-05-05T14:00",
+            loop="anl",
+            model=mdl,
+            system=system,
+            domain=domain,
+            frequency=frequency,
+            background=background,
         )
 
         diag.save(session, zarr_file, ps)
@@ -111,30 +111,30 @@ class TestSaveNew:
 
 class TestAddVariable:
     @pytest.fixture(scope="class", autouse=True)
-    def dataset(self, model, diag_dataset, session, zarr_file):
+    def dataset(self, model, test_dataset, session, zarr_file):
         (mdl, system, domain, background, frequency) = model
-        ps = diag_dataset(
-            "ps",
-            "2022-05-05T14:00",
-            "anl",
-            mdl,
-            system,
-            domain,
-            frequency,
-            background,
+        ps = test_dataset(
+            variable="ps",
+            initialization_time="2022-05-05T14:00",
+            loop="anl",
+            model=mdl,
+            system=system,
+            domain=domain,
+            frequency=frequency,
+            background=background,
         )
 
         diag.save(session, zarr_file, ps)
 
-        t = diag_dataset(
-            "t",
-            "2022-05-05T14:00",
-            "anl",
-            mdl,
-            system,
-            domain,
-            frequency,
-            background,
+        t = test_dataset(
+            variable="t",
+            initialization_time="2022-05-05T14:00",
+            loop="anl",
+            model=mdl,
+            system=system,
+            domain=domain,
+            frequency=frequency,
+            background=background,
         )
 
         diag.save(session, zarr_file, t)
@@ -168,30 +168,30 @@ class TestAddVariable:
 
 class TestAddLoop:
     @pytest.fixture(scope="class", autouse=True)
-    def dataset(self, model, diag_dataset, session, zarr_file):
+    def dataset(self, model, test_dataset, session, zarr_file):
         (mdl, system, domain, background, frequency) = model
-        ges = diag_dataset(
-            "ps",
-            "2022-05-05T14:00",
-            "ges",
-            mdl,
-            system,
-            domain,
-            frequency,
-            background,
+        ges = test_dataset(
+            variable="ps",
+            initialization_time="2022-05-05T14:00",
+            loop="ges",
+            model=mdl,
+            system=system,
+            domain=domain,
+            frequency=frequency,
+            background=background,
         )
 
         diag.save(session, zarr_file, ges)
 
-        anl = diag_dataset(
-            "ps",
-            "2022-05-05T14:00",
-            "anl",
-            mdl,
-            system,
-            domain,
-            frequency,
-            background,
+        anl = test_dataset(
+            variable="ps",
+            initialization_time="2022-05-05T14:00",
+            loop="anl",
+            model=mdl,
+            system=system,
+            domain=domain,
+            frequency=frequency,
+            background=background,
         )
 
         diag.save(session, zarr_file, anl)
@@ -230,30 +230,30 @@ class TestAddLoop:
 
 class TestAddAnalysis:
     @pytest.fixture(scope="class", autouse=True)
-    def dataset(self, model, diag_dataset, session, zarr_file):
+    def dataset(self, model, test_dataset, session, zarr_file):
         (mdl, system, domain, background, frequency) = model
-        first = diag_dataset(
-            "ps",
-            "2022-05-05T14:00",
-            "ges",
-            mdl,
-            system,
-            domain,
-            frequency,
-            background,
+        first = test_dataset(
+            variable="ps",
+            initialization_time="2022-05-05T14:00",
+            loop="ges",
+            model=mdl,
+            system=system,
+            domain=domain,
+            frequency=frequency,
+            background=background,
         )
 
         diag.save(session, zarr_file, first)
 
-        second = diag_dataset(
-            "ps",
-            "2022-05-05T15:00",
-            "ges",
-            mdl,
-            system,
-            domain,
-            frequency,
-            background,
+        second = test_dataset(
+            variable="ps",
+            initialization_time="2022-05-05T15:00",
+            loop="ges",
+            model=mdl,
+            system=system,
+            domain=domain,
+            frequency=frequency,
+            background=background,
         )
 
         diag.save(session, zarr_file, second)

--- a/tests/test_diag.py
+++ b/tests/test_diag.py
@@ -294,15 +294,19 @@ def test_vector_magnitude():
         ([("a", "1::2")], [("a", np.array([1.0]), np.array([2.0]))]),
         ([("a", "2,4::3,1")], [("a", np.array([2.0, 1.0]), np.array([3.0, 4.0]))]),
     ],
+    scope="class",
 )
-def test_get_bounds(mapping, expected):
-    filters = MultiDict(mapping)
+class TestGetBounds:
+    @pytest.fixture(scope="class")
+    def result(self, mapping):
+        filters = MultiDict(mapping)
+        return list(diag.get_bounds(filters))
 
-    result = list(diag.get_bounds(filters))
+    def test_coord(self, result, expected):
+        assert result[0][0] == expected[0][0]
 
-    for (coord, lower, upper), (expected_coord, expected_lower, expected_upper) in zip(
-        result, expected
-    ):
-        assert coord == expected_coord
-        assert (lower == expected_lower).all()
-        assert (upper == expected_upper).all()
+    def test_lower_bounds(self, result, expected):
+        assert (result[0][1] == expected[0][1]).all()
+
+    def test_upper_bounds(self, result, expected):
+        assert (result[0][2] == expected[0][2]).all()

--- a/tests/test_diag.py
+++ b/tests/test_diag.py
@@ -113,7 +113,8 @@ def test_get_store_s3(moto_server, s3_client, monkeypatch):
     )
 
 
-def test_open_diagnostic(diag_zarr_file, test_dataset):
+def test_open_diagnostic(tmp_path, test_dataset):
+    diag_zarr_file = str(tmp_path / "test_diag.zarr")
     expected = test_dataset()
     group = "/".join(
         (

--- a/tests/test_diag.py
+++ b/tests/test_diag.py
@@ -41,14 +41,15 @@ def test_get_model_metadata(session):
 
     result = diag.get_model_metadata(session)
 
-    assert result
-    assert result.model_list == ["3DRTMA", "RTMA"]
-    assert result.system_list == ["JET", "WCOSS"]
-    assert result.domain_list == ["CONUS"]
-    assert result.frequency_list == ["REALTIME", "RETRO"]
-    assert result.background_list == ["HRRR", "RRFS"]
-    assert result.init_time_list == ["2023-03-17T14:00", "2023-03-17T15:00"]
-    assert result.variable_list == variable_list
+    assert result == diag.ModelMetadata(
+        model_list=["3DRTMA", "RTMA"],
+        system_list=["JET", "WCOSS"],
+        domain_list=["CONUS"],
+        frequency_list=["REALTIME", "RETRO"],
+        background_list=["HRRR", "RRFS"],
+        init_time_list=["2023-03-17T14:00", "2023-03-17T15:00"],
+        variable_list=variable_list,
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_unified_graphics.py
+++ b/tests/test_unified_graphics.py
@@ -1,24 +1,91 @@
 from pathlib import Path
-from typing import Optional
 
-import numpy as np
 import pytest  # noqa: F401
 import xarray as xr
 
 from unified_graphics import create_app
 
 
-@pytest.fixture
-def diag_zarr_file(tmp_path):
-    return str(tmp_path / "test_diag.zarr")
+def get_group(ds: xr.Dataset) -> str:
+    return "/".join(
+        [
+            ds.model,
+            ds.system,
+            ds.domain,
+            ds.background,
+            ds.frequency,
+            ds.name,
+            ds.initialization_time,
+            ds.loop,
+        ]
+    )
+
+
+def save(store: Path, data: xr.Dataset):
+    data.to_zarr(store, group=get_group(data), consolidated=False)
+
+
+@pytest.fixture(scope="module")
+def model():
+    return {
+        "model": "3DRTMA",
+        "system": "WCOSS",
+        "domain": "CONUS",
+        "background": "HRRR",
+        "frequency": "REALTIME",
+    }
 
 
 @pytest.fixture
-def app(diag_zarr_file, test_db):
+def diag_zarr_path(tmp_path):
+    return tmp_path / "test_diag.zarr"
+
+
+@pytest.fixture
+def t(model, diag_zarr_path, test_dataset):
+    ds = test_dataset(
+        **model,
+        initialization_time="2022-05-16T04:00",
+        loop="ges",
+        variable="t",
+        observation=[1, 0, 2],
+        forecast_unadjusted=[0, 1, -1],
+        longitude=[90, 91, 89],
+        latitude=[22, 23, 24],
+        is_used=[1, 1, 0],
+    )
+
+    save(diag_zarr_path, ds)
+
+    return ds
+
+
+@pytest.fixture
+def uv(model, diag_zarr_path, test_dataset):
+    ds = test_dataset(
+        **model,
+        variable="uv",
+        initialization_time="2022-05-16T04:00",
+        loop="ges",
+        observation=[[0, 1], [1, 0]],
+        forecast_unadjusted=[[0, 0], [1, 1]],
+        longitude=[90, 91],
+        latitude=[22, 23],
+        is_used=[1, 1],
+        component=["u", "v"],
+    )
+
+    save(diag_zarr_path, ds)
+
+    return ds
+
+
+@pytest.fixture
+def app(diag_zarr_path, test_db):
     _app = create_app(
         {
             "SQLALCHEMY_DATABASE_URI": test_db,
-            "DIAG_ZARR": diag_zarr_file,
+            "DIAG_ZARR": str(diag_zarr_path),
         }
     )
 
@@ -33,146 +100,19 @@ def client(app):
         yield c
 
 
-@pytest.fixture(scope="session")
-def diag_dataset():
-    def factory(
-        variable: str,
-        initialization_time: str,
-        loop: str,
-        model: Optional[str] = None,
-        system: Optional[str] = None,
-        domain: Optional[str] = None,
-        frequency: Optional[str] = None,
-        background: Optional[str] = None,
-        data: Optional[xr.Dataset] = None,
-        **kwargs,
-    ):
-        dims = ["nobs", *kwargs.keys()]
-        shape = [3, *map(len, kwargs.values())]
-        variables = [
-            "observation",
-            "forecast_adjusted",
-            "obs_minus_forecast_adjusted",
-            "forecast_unadjusted",
-            "obs_minus_forecast_unadjusted",
-        ]
-
-        if data:
-            ds = data
-            ds.attrs.update(
-                name=variable, loop=loop, initialization_time=initialization_time
-            )
-        else:
-            ds = xr.Dataset(
-                {var: (dims, np.zeros(shape)) for var in variables},
-                coords=dict(
-                    longitude=(["nobs"], np.array([90, 91, -160], dtype=np.float64)),
-                    latitude=(["nobs"], np.array([22, 23, 25], dtype=np.float64)),
-                    is_used=(["nobs"], np.array([1, 0, 1], dtype=np.int8)),
-                    **kwargs,
-                ),
-                attrs={
-                    "name": variable,
-                    "loop": loop,
-                    "initialization_time": initialization_time,
-                    "model": model or "Unknown",
-                    "system": system or "Unknown",
-                    "domain": domain or "Unknown",
-                    "frequency": frequency or "Unknown",
-                    "background": background or "Unknown",
-                },
-            )
-
-        return ds
-
-    return factory
+@pytest.mark.xfail(reason="Needs to be updated to expect HTML response")
+def test_home_page(client):
+    assert 0
 
 
-@pytest.fixture
-def diag_zarr(diag_zarr_file, diag_dataset):
-    def factory(
-        variables: list[str],
-        initialization_time: str,
-        loop: str,
-        model: Optional[str] = "RTMA",
-        system: Optional[str] = "WCOSS",
-        domain: Optional[str] = "CONUS",
-        frequency: Optional[str] = "REALTIME",
-        background: Optional[str] = "HRRR",
-        zarr_file: str = "",
-        data: Optional[xr.Dataset] = None,
-    ):
-        if not zarr_file:
-            zarr_file = diag_zarr_file
+def test_scalar_diag(t, client):
+    # Arrange
+    group = get_group(t)
 
-        if data:
-            group = (
-                f"/{data.model}/{data.system}/{data.domain}/{data.background}"
-                f"/{data.frequency}/{data.attrs['name']}/{initialization_time}/{loop}"
-            )
-            data.to_zarr(zarr_file, group=group, consolidated=False)
-            return zarr_file
+    # Act
+    response = client.get(f"/diag/{group}/")
 
-        for variable in variables:
-            coords = {"component": ["u", "v"]} if variable == "uv" else {}
-
-            ds = diag_dataset(
-                variable,
-                initialization_time,
-                loop,
-                model,
-                system,
-                domain,
-                frequency,
-                background,
-                **coords,
-            )
-            try:
-                group = (
-                    f"/{ds.model}/{ds.system}/{ds.domain}/{ds.background}"
-                    f"/{ds.frequency}/{variable}/{initialization_time}/{loop}"
-                )
-                ds.to_zarr(zarr_file, group=group, consolidated=False)
-            except Exception as e:
-                raise e
-
-        return zarr_file
-
-    return factory
-
-
-class TestHomePage:
-    @pytest.fixture
-    def response(self, client):
-        return client.get("/")
-
-    def test_http_status(self, response):
-        assert response.status_code == 200
-
-    @pytest.mark.xfail(reason="Needs to be updated to expect HTML response")
-    def test_page(self, response):
-        assert 0
-
-
-@pytest.mark.parametrize(
-    "variable_name,variable_code,loop",
-    [("temperature", "t", "anl"), ("moisture", "q", "ges")],
-)
-def test_scalar_diag(variable_name, variable_code, loop, diag_zarr, client):
-    model = "RTMA"
-    system = "WCOSS"
-    domain = "CONUS"
-    background = "HRRR"
-    frequency = "REALTIME"
-    init_time = "2022-05-16T04:00"
-    diag_zarr([variable_code], init_time, loop)
-
-    response = client.get(
-        f"/diag/{model}/{system}/{domain}/{background}/{frequency}"
-        f"/{variable_code}/{init_time}/{loop}/"
-    )
-
-    assert response.status_code == 200
+    # Assert
     assert response.json == {
         "type": "FeatureCollection",
         "features": [
@@ -180,31 +120,32 @@ def test_scalar_diag(variable_name, variable_code, loop, diag_zarr, client):
                 "type": "Feature",
                 "properties": {
                     "type": "scalar",
-                    "loop": loop,
-                    "variable": variable_name,
-                    "adjusted": 0,
-                    "unadjusted": 0,
-                    "observed": 0,
+                    "loop": t.loop,
+                    "variable": "temperature",
+                    "adjusted": 1.0,
+                    "unadjusted": 1.0,
+                    "observed": 1.0,
                 },
-                "geometry": {"type": "Point", "coordinates": [90, 22]},
+                "geometry": {"type": "Point", "coordinates": [90.0, 22.0]},
             },
             {
                 "type": "Feature",
                 "properties": {
                     "type": "scalar",
-                    "loop": loop,
-                    "variable": variable_name,
-                    "adjusted": 0,
-                    "unadjusted": 0,
-                    "observed": 0,
+                    "loop": t.loop,
+                    "variable": "temperature",
+                    "adjusted": -1.0,
+                    "unadjusted": -1.0,
+                    "observed": 0.0,
                 },
-                "geometry": {"type": "Point", "coordinates": [-160, 25]},
+                "geometry": {"type": "Point", "coordinates": [91.0, 23.0]},
             },
         ],
     }
 
 
-def test_scalar_history(diag_zarr, test_dataset, client):
+def test_scalar_history(model, diag_zarr_path, client, test_dataset):
+    # Arrange
     run_list = [
         {
             "initialization_time": "2022-05-16T04:00",
@@ -225,12 +166,19 @@ def test_scalar_history(diag_zarr, test_dataset, client):
     ]
 
     for run in run_list:
-        data = test_dataset(**run)
-        diag_zarr([data.name], data.initialization_time, data.loop, data=data)
+        data = test_dataset(
+            **model,
+            variable="ps",
+            loop="ges",
+            **run,
+        )
 
-    response = client.get("/diag/RTMA/WCOSS/CONUS/HRRR/REALTIME/ps/ges/")
+        save(diag_zarr_path, data)
 
-    assert response.status_code == 200
+    # Act
+    response = client.get("/diag/3DRTMA/WCOSS/CONUS/HRRR/REALTIME/ps/ges/")
+
+    # Assert
     assert response.json == [
         {
             "initialization_time": "2022-05-16T04:00",
@@ -273,7 +221,8 @@ def test_scalar_history(diag_zarr, test_dataset, client):
     ]
 
 
-def test_scalar_history_unused(diag_zarr, test_dataset, client):
+def test_scalar_history_unused(model, diag_zarr_path, client, test_dataset):
+    # Arrange
     run_list = [
         {
             "initialization_time": "2022-05-16T04:00",
@@ -292,12 +241,18 @@ def test_scalar_history_unused(diag_zarr, test_dataset, client):
     ]
 
     for run in run_list:
-        data = test_dataset(**run)
-        diag_zarr([data.name], data.initialization_time, data.loop, data=data)
+        data = test_dataset(
+            **model,
+            variable="ps",
+            loop="ges",
+            **run,
+        )
+        save(diag_zarr_path, data)
 
-    response = client.get("/diag/RTMA/WCOSS/CONUS/HRRR/REALTIME/ps/ges/")
+    # Act
+    response = client.get("/diag/3DRTMA/WCOSS/CONUS/HRRR/REALTIME/ps/ges/")
 
-    assert response.status_code == 200
+    # Assert
     assert response.json == [
         {
             "initialization_time": "2022-05-16T04:00",
@@ -340,7 +295,8 @@ def test_scalar_history_unused(diag_zarr, test_dataset, client):
     ]
 
 
-def test_scalar_history_empty(diag_zarr, test_dataset, client):
+def test_scalar_history_empty(model, diag_zarr_path, client, test_dataset):
+    # Arrange
     run_list = [
         {
             "initialization_time": "2022-05-16T04:00",
@@ -353,12 +309,18 @@ def test_scalar_history_empty(diag_zarr, test_dataset, client):
     ]
 
     for run in run_list:
-        data = test_dataset(**run)
-        diag_zarr([data.name], data.initialization_time, data.loop, data=data)
+        data = test_dataset(
+            **model,
+            variable="ps",
+            loop="ges",
+            **run,
+        )
+        save(diag_zarr_path, data)
 
-    response = client.get("/diag/RTMA/WCOSS/CONUS/HRRR/REALTIME/ps/ges/")
+    # Act
+    response = client.get("/diag/3DRTMA/WCOSS/CONUS/HRRR/REALTIME/ps/ges/")
 
-    assert response.status_code == 200
+    # Assert
     assert response.json == []
 
 
@@ -367,22 +329,14 @@ def test_vectory_history():
     assert 0, "Not implemented"
 
 
-def test_wind_diag(diag_zarr, client):
-    model = "RTMA"
-    system = "WCOSS"
-    domain = "CONUS"
-    background = "HRRR"
-    frequency = "REALTIME"
-    init_time = "2022-05-16T04:00"
-    loop = "ges"
-    diag_zarr(["uv"], init_time, loop)
+def test_wind_diag(uv, client):
+    # Arrange
+    group = get_group(uv)
 
-    response = client.get(
-        f"/diag/{model}/{system}/{domain}/{background}"
-        f"/{frequency}/uv/{init_time}/{loop}/"
-    )
+    # Act
+    response = client.get(f"/diag/{group}/")
 
-    assert response.status_code == 200
+    # Assert
     assert response.json == {
         "type": "FeatureCollection",
         "features": [
@@ -391,10 +345,10 @@ def test_wind_diag(diag_zarr, client):
                 "properties": {
                     "type": "vector",
                     "variable": "wind",
-                    "loop": loop,
-                    "adjusted": {"u": 0.0, "v": 0.0},
-                    "unadjusted": {"u": 0.0, "v": 0.0},
-                    "observed": {"u": 0.0, "v": 0.0},
+                    "loop": "ges",
+                    "adjusted": {"u": 0.0, "v": 1.0},
+                    "unadjusted": {"u": 0.0, "v": 1.0},
+                    "observed": {"u": 0.0, "v": 1.0},
                 },
                 "geometry": {"type": "Point", "coordinates": [90, 22]},
             },
@@ -403,27 +357,25 @@ def test_wind_diag(diag_zarr, client):
                 "properties": {
                     "type": "vector",
                     "variable": "wind",
-                    "loop": loop,
-                    "adjusted": {"u": 0.0, "v": 0.0},
-                    "unadjusted": {"u": 0.0, "v": 0.0},
-                    "observed": {"u": 0.0, "v": 0.0},
+                    "loop": "ges",
+                    "adjusted": {"u": 0.0, "v": -1.0},
+                    "unadjusted": {"u": 0.0, "v": -1.0},
+                    "observed": {"u": 1.0, "v": 0.0},
                 },
-                "geometry": {"type": "Point", "coordinates": [-160.0, 25.0]},
+                "geometry": {"type": "Point", "coordinates": [91.0, 23.0]},
             },
         ],
     }
 
 
-def test_vector_magnitude(diag_zarr, client):
-    init_time = "2022-05-16T04:00"
-    loop = "ges"
-    diag_zarr(["uv"], init_time, loop)
+def test_vector_magnitude(uv, client):
+    # Arrange
+    group = get_group(uv)
 
-    response = client.get(
-        f"/diag/RTMA/WCOSS/CONUS/HRRR/REALTIME/uv/{init_time}/{loop}/magnitude/"
-    )
+    # Act
+    response = client.get(f"/diag/{group}/magnitude/")
 
-    assert response.status_code == 200
+    # Assert
     assert response.json == {
         "type": "FeatureCollection",
         "features": [
@@ -432,49 +384,36 @@ def test_vector_magnitude(diag_zarr, client):
                 "properties": {
                     "type": "vector",
                     "variable": "wind",
-                    "loop": loop,
-                    "adjusted": 0.0,
-                    "unadjusted": 0.0,
-                    "observed": 0.0,
+                    "loop": "ges",
+                    "adjusted": 1.0,
+                    "unadjusted": 1.0,
+                    "observed": 1.0,
                 },
-                "geometry": {"type": "Point", "coordinates": [90, 22]},
+                "geometry": {"type": "Point", "coordinates": [90.0, 22.0]},
             },
             {
                 "type": "Feature",
                 "properties": {
                     "type": "vector",
                     "variable": "wind",
-                    "loop": loop,
-                    "adjusted": 0.0,
-                    "unadjusted": 0.0,
-                    "observed": 0.0,
+                    "loop": "ges",
+                    "adjusted": 1.0,
+                    "unadjusted": 1.0,
+                    "observed": 1.0,
                 },
-                "geometry": {"type": "Point", "coordinates": [-160.0, 25.0]},
+                "geometry": {"type": "Point", "coordinates": [91.0, 23.0]},
             },
         ],
     }
 
 
-def test_region_filter_scalar(diag_zarr, client):
-    model = "RTMA"
-    system = "WCOSS"
-    domain = "CONUS"
-    background = "HRRR"
-    frequency = "REALTIME"
-    init_time = "2022-05-16T04:00"
-    loop = "ges"
-    variable = "t"
-    variable_name = "temperature"
-    diag_zarr([variable], init_time, loop)
+def test_region_filter_scalar(t, client):
+    group = get_group(t)
 
-    url = (
-        f"/diag/{model}/{system}/{domain}/{background}"
-        f"/{frequency}/{variable}/{init_time}/{loop}/"
-    )
-    query = "longitude=-160.1::-159.9&latitude=27::22"
+    url = f"/diag/{group}/"
+    query = "longitude=89.9::90.5&latitude=27::22"
     response = client.get(f"{url}?{query}")
 
-    assert response.status_code == 200
     assert response.json == {
         "type": "FeatureCollection",
         "features": [
@@ -482,62 +421,28 @@ def test_region_filter_scalar(diag_zarr, client):
                 "type": "Feature",
                 "properties": {
                     "type": "scalar",
-                    "loop": loop,
-                    "variable": variable_name,
-                    "adjusted": 0,
-                    "unadjusted": 0,
-                    "observed": 0,
+                    "loop": "ges",
+                    "variable": "temperature",
+                    "adjusted": 1.0,
+                    "unadjusted": 1.0,
+                    "observed": 1.0,
                 },
-                "geometry": {"type": "Point", "coordinates": [-160, 25]},
+                "geometry": {"type": "Point", "coordinates": [90.0, 22.0]},
             },
         ],
     }
 
 
-def test_range_filter_scalar(diag_zarr, client):
-    model = "RTMA"
-    system = "WCOSS"
-    domain = "CONUS"
-    frequency = "REALTIME"
-    background = "HRRR"
-    init_time = "2022-05-16T04:00"
-    loop = "ges"
-    variable = "t"
-    variable_name = "temperature"
-    data = xr.Dataset(
-        {
-            "obs_minus_forecast_adjusted": (["nobs"], [0, 1]),
-            "obs_minus_forecast_unadjusted": (["nobs"], [0, 2]),
-            "observation": (["nobs"], [0, 2]),
-            "forecast_adjusted": (["nobs"], [0, 1]),
-            "forecast_unadjusted": (["nobs"], [0, 0]),
-        },
-        coords=dict(
-            longitude=(["nobs"], [90, -160]),
-            latitude=(["nobs"], [22, 25]),
-            is_used=(["nobs"], [0, 1]),
-        ),
-        attrs={
-            "name": variable,
-            "loop": loop,
-            "initialization_time": init_time,
-            "model": model,
-            "system": system,
-            "domain": domain,
-            "frequency": frequency,
-            "background": background,
-        },
-    )
-    diag_zarr([variable], init_time, loop, model, system, domain, frequency, data=data)
-
-    url = (
-        f"/diag/{model}/{system}/{domain}/{background}"
-        f"/{frequency}/{variable}/{init_time}/{loop}/"
-    )
+def test_range_filter_scalar(t, client):
+    # Arrange
+    group = get_group(t)
+    url = f"/diag/{group}/"
     query = "obs_minus_forecast_adjusted=1.5::1"
+
+    # Act
     response = client.get(f"{url}?{query}")
 
-    assert response.status_code == 200
+    # Assert
     assert response.json == {
         "type": "FeatureCollection",
         "features": [
@@ -545,38 +450,27 @@ def test_range_filter_scalar(diag_zarr, client):
                 "type": "Feature",
                 "properties": {
                     "type": "scalar",
-                    "loop": loop,
-                    "variable": variable_name,
-                    "adjusted": 1,
-                    "unadjusted": 2,
-                    "observed": 2,
+                    "loop": t.loop,
+                    "variable": "temperature",
+                    "adjusted": 1.0,
+                    "unadjusted": 1.0,
+                    "observed": 1.0,
                 },
-                "geometry": {"type": "Point", "coordinates": [-160, 25]},
+                "geometry": {"type": "Point", "coordinates": [90.0, 22.0]},
             },
         ],
     }
 
 
-def test_region_filter_vector(diag_zarr, client):
-    model = "RTMA"
-    system = "WCOSS"
-    domain = "CONUS"
-    background = "HRRR"
-    frequency = "REALTIME"
-    init_time = "2022-05-16T04:00"
-    loop = "ges"
-    variable = "uv"
-    variable_name = "wind"
-    diag_zarr([variable], init_time, loop)
+def test_region_filter_vector(uv, client):
+    # Arrange
+    group = get_group(uv)
+    url = f"/diag/{group}/"
+    query = "longitude=89.9::90.5&latitude=27::22"
 
-    url = (
-        f"/diag/{model}/{system}/{domain}/{background}"
-        f"/{frequency}/{variable}/{init_time}/{loop}/"
-    )
-    query = "longitude=-160.1::-159.9&latitude=27::22"
+    # Act
     response = client.get(f"{url}?{query}")
 
-    assert response.status_code == 200
     assert response.json == {
         "type": "FeatureCollection",
         "features": [
@@ -584,13 +478,13 @@ def test_region_filter_vector(diag_zarr, client):
                 "type": "Feature",
                 "properties": {
                     "type": "vector",
-                    "variable": variable_name,
-                    "loop": loop,
-                    "adjusted": {"u": 0.0, "v": 0.0},
-                    "unadjusted": {"u": 0.0, "v": 0.0},
-                    "observed": {"u": 0.0, "v": 0.0},
+                    "variable": "wind",
+                    "loop": uv.loop,
+                    "adjusted": {"u": 0.0, "v": 1.0},
+                    "unadjusted": {"u": 0.0, "v": 1.0},
+                    "observed": {"u": 0.0, "v": 1.0},
                 },
-                "geometry": {"type": "Point", "coordinates": [-160.0, 25.0]},
+                "geometry": {"type": "Point", "coordinates": [90.0, 22.0]},
             },
         ],
     }
@@ -612,57 +506,20 @@ def test_region_filter_vector(diag_zarr, client):
 # the Nan values. You can see the fix in commit 7f92e15fbdcde7fd683143f6bf429f2b45fac3d2
 # that got this working in production, but I was unable to reproduce the issue in
 # the test.
-def test_range_filter_vector(diag_zarr, client):
-    model = "RTMA"
-    system = "WCOSS"
-    domain = "CONUS"
-    frequency = "REALTIME"
-    background = "HRRR"
-    init_time = "2022-05-16T04:00"
-    loop = "ges"
-    variable = "uv"
-    variable_name = "wind"
-    data = xr.Dataset(
-        {
-            "obs_minus_forecast_adjusted": (["nobs", "component"], [[0, 1], [10, 20]]),
-            "obs_minus_forecast_unadjusted": (
-                ["nobs", "component"],
-                [[0, 2], [10, 25]],
-            ),
-            "observation": (["nobs", "component"], [[0, 2], [20, 50]]),
-            "forecast_adjusted": (["nobs", "component"], [[0, 1], [10, 30]]),
-            "forecast_unadjusted": (["nobs", "component"], [[0, 0], [10, 25]]),
-        },
-        coords=dict(
-            component=["u", "v"],
-            longitude=(["nobs"], [90, -160]),
-            latitude=(["nobs"], [22, 25]),
-            is_used=(["nobs"], [1, 0]),
-        ),
-        attrs={
-            "name": variable,
-            "loop": loop,
-            "initialization_time": init_time,
-            "model": model,
-            "system": system,
-            "domain": domain,
-            "frequency": frequency,
-            "background": background,
-        },
-    )
-    diag_zarr([variable], init_time, loop, data=data)
+def test_range_filter_vector(uv, client):
+    # Arrange
+    group = get_group(uv)
+    url = f"/diag/{group}/"
 
-    url = (
-        f"/diag/{model}/{system}/{domain}/{background}"
-        f"/{frequency}/{variable}/{init_time}/{loop}/"
-    )
     # This query is designed so that both observations v components fall within the
     # selected region, but only the first observation's u component does, so only the
     # first observation should be returned
-    query = "obs_minus_forecast_adjusted=1::-1&obs_minus_forecast_adjusted=0::25"
+    query = "obs_minus_forecast_adjusted=1::-0.5&obs_minus_forecast_adjusted=0::25"
+
+    # Act
     response = client.get(f"{url}?{query}")
 
-    assert response.status_code == 200
+    # Assert
     assert response.json == {
         "type": "FeatureCollection",
         "features": [
@@ -670,38 +527,28 @@ def test_range_filter_vector(diag_zarr, client):
                 "type": "Feature",
                 "properties": {
                     "type": "vector",
-                    "variable": variable_name,
-                    "loop": loop,
-                    "adjusted": {"u": 0, "v": 1},
-                    "unadjusted": {"u": 0, "v": 2},
-                    "observed": {"u": 0, "v": 2},
+                    "variable": "wind",
+                    "loop": uv.loop,
+                    "adjusted": {"u": 0.0, "v": 1.0},
+                    "unadjusted": {"u": 0.0, "v": 1.0},
+                    "observed": {"u": 0.0, "v": 1.0},
                 },
-                "geometry": {"type": "Point", "coordinates": [90, 22]},
+                "geometry": {"type": "Point", "coordinates": [90.0, 22.0]},
             },
         ],
     }
 
 
-def test_unused_filter(diag_zarr, client):
-    model = "RTMA"
-    system = "WCOSS"
-    domain = "CONUS"
-    background = "HRRR"
-    frequency = "REALTIME"
-    variable_code = "t"
-    variable_name = "temperature"
-    loop = "ges"
-    init_time = "2022-05-16T04:00"
-    diag_zarr([variable_code], init_time, loop)
-
-    url = (
-        f"/diag/{model}/{system}/{domain}/{background}"
-        f"/{frequency}/{variable_code}/{init_time}/{loop}/"
-    )
+def test_unused_filter(t, client):
+    # Arrange
+    group = get_group(t)
+    url = f"/diag/{group}/"
     query = "is_used=false"
+
+    # Act
     response = client.get(f"{url}?{query}")
 
-    assert response.status_code == 200
+    # Assert
     assert response.json == {
         "type": "FeatureCollection",
         "features": [
@@ -709,34 +556,22 @@ def test_unused_filter(diag_zarr, client):
                 "type": "Feature",
                 "properties": {
                     "type": "scalar",
-                    "loop": loop,
-                    "variable": variable_name,
-                    "adjusted": 0,
-                    "unadjusted": 0,
-                    "observed": 0,
+                    "loop": t.loop,
+                    "variable": "temperature",
+                    "adjusted": 3.0,
+                    "unadjusted": 3.0,
+                    "observed": 2.0,
                 },
-                "geometry": {"type": "Point", "coordinates": [91, 23]},
+                "geometry": {"type": "Point", "coordinates": [89.0, 24.0]},
             },
         ],
     }
 
 
-def test_all_obs_filter(diag_zarr, client):
-    model = "RTMA"
-    system = "WCOSS"
-    domain = "CONUS"
-    background = "HRRR"
-    frequency = "REALTIME"
-    variable_code = "t"
-    variable_name = "temperature"
-    loop = "ges"
-    init_time = "2022-05-16T04:00"
-    diag_zarr([variable_code], init_time, loop)
+def test_all_obs_filter(t, client):
+    group = get_group(t)
 
-    url = (
-        f"/diag/{model}/{system}/{domain}/{background}"
-        f"/{frequency}/{variable_code}/{init_time}/{loop}/"
-    )
+    url = f"/diag/{group}/"
     query = "is_used=true::false"
     response = client.get(f"{url}?{query}")
 
@@ -748,37 +583,37 @@ def test_all_obs_filter(diag_zarr, client):
                 "type": "Feature",
                 "properties": {
                     "type": "scalar",
-                    "loop": loop,
-                    "variable": variable_name,
-                    "adjusted": 0,
-                    "unadjusted": 0,
-                    "observed": 0,
+                    "loop": t.loop,
+                    "variable": "temperature",
+                    "adjusted": 1.0,
+                    "unadjusted": 1.0,
+                    "observed": 1.0,
                 },
-                "geometry": {"type": "Point", "coordinates": [90, 22]},
+                "geometry": {"type": "Point", "coordinates": [90.0, 22.0]},
             },
             {
                 "type": "Feature",
                 "properties": {
                     "type": "scalar",
-                    "loop": loop,
-                    "variable": variable_name,
-                    "adjusted": 0,
-                    "unadjusted": 0,
-                    "observed": 0,
+                    "loop": t.loop,
+                    "variable": "temperature",
+                    "adjusted": -1.0,
+                    "unadjusted": -1.0,
+                    "observed": 0.0,
                 },
-                "geometry": {"type": "Point", "coordinates": [91, 23]},
+                "geometry": {"type": "Point", "coordinates": [91.0, 23.0]},
             },
             {
                 "type": "Feature",
                 "properties": {
                     "type": "scalar",
-                    "loop": loop,
-                    "variable": variable_name,
-                    "adjusted": 0,
-                    "unadjusted": 0,
-                    "observed": 0,
+                    "loop": t.loop,
+                    "variable": "temperature",
+                    "adjusted": 3.0,
+                    "unadjusted": 3.0,
+                    "observed": 2.0,
                 },
-                "geometry": {"type": "Point", "coordinates": [-160, 25]},
+                "geometry": {"type": "Point", "coordinates": [89.0, 24.0]},
             },
         ],
     }

--- a/tests/test_unified_graphics.py
+++ b/tests/test_unified_graphics.py
@@ -141,11 +141,17 @@ def diag_zarr(diag_zarr_file, diag_dataset):
     return factory
 
 
-@pytest.mark.xfail(reason="Needs to be updated to expect HTML response")
-def test_root_endpoint(client):
-    response = client.get("/")
+class TestHomePage:
+    @pytest.fixture
+    def response(self, client):
+        return client.get("/")
 
-    assert response.status_code == 200
+    def test_http_status(self, response):
+        assert response.status_code == 200
+
+    @pytest.mark.xfail(reason="Needs to be updated to expect HTML response")
+    def test_page(self, response):
+        assert 0
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Cleaning up test organization and fixtures in an attempt to make the tests clearer and easier to write.

Removed a number of global fixtures from `conftest.py` that aren’t needed globally. All of the Flask app fixtures are moved to the `test_unified_graphics.py` module. I eliminated some of the old fixtures for generating test data in favor of the `test_dataset` fixture which is more flexible.

I also tried to ensure that every test only asserts one condition, using the [class pattern for safely asserting multiple statements][1]. This way one failed assertion doesn't mask other failed conditions; if multiple conditions are failing in a test, we will be notified by all of them at once.

Finally, I eliminated the `--runaws` flag by adding `moto` for mocking an S3 server locally for our tests. This means we’re no longer skipping any tests in CI.

[1]: https://docs.pytest.org/en/7.3.x/how-to/fixtures.html#running-multiple-assert-statements-safely