### PR TITLE
Run CI whenever anything in tests/ changes

### DIFF
--- a/.github/workflows/api.yaml
+++ b/.github/workflows/api.yaml
@@ -9,12 +9,14 @@ on:
     paths:
       - "src/**/*.py"
       - "src/**/*.html"
+      - "tests/**/*"
       - ".github/workflows/**"
       - ".github/scripts/**"
   pull_request:
     paths:
       - "src/**/*.py"
       - "src/**/*.html"
+      - "tests/**/*"
       - ".github/workflows/**"
       - ".github/scripts/**"
   workflow_dispatch: # Manually


### PR DESCRIPTION
Add `tests/**/*` to the paths we check for changes when running CI, so that if we are just changing tests, they run in the PR. We don't want to accidentally break tests just because we didn’t change the application.