### PR TITLE
Switch dev dependencies to Poetry groups

### DIFF
--- a/.github/workflows/api.yaml
+++ b/.github/workflows/api.yaml
@@ -14,6 +14,8 @@ on:
       - ".github/scripts/**"
       - "pyproject.toml"
       - "poetry.lock"
+      - "docker/app/**"
+      - "docker/diag-etl/**"
   pull_request:
     paths:
       - "src/**/*.py"
@@ -23,6 +25,8 @@ on:
       - ".github/scripts/**"
       - "pyproject.toml"
       - "poetry.lock"
+      - "docker/app/**"
+      - "docker/diag-etl/**"
   workflow_dispatch: # Manually
 env:
   REGISTRY: ghcr.io/noaa-gsl/unified-graphics

--- a/.github/workflows/api.yaml
+++ b/.github/workflows/api.yaml
@@ -12,6 +12,8 @@ on:
       - "tests/**/*"
       - ".github/workflows/**"
       - ".github/scripts/**"
+      - "pyproject.toml"
+      - "poetry.lock"
   pull_request:
     paths:
       - "src/**/*.py"
@@ -19,6 +21,8 @@ on:
       - "tests/**/*"
       - ".github/workflows/**"
       - ".github/scripts/**"
+      - "pyproject.toml"
+      - "poetry.lock"
   workflow_dispatch: # Manually
 env:
   REGISTRY: ghcr.io/noaa-gsl/unified-graphics

--- a/.github/workflows/ui.yaml
+++ b/.github/workflows/ui.yaml
@@ -13,6 +13,7 @@ on:
       - "src/*/static/**"
       - ".github/workflows/**"
       - ".github/scripts/**"
+      - "docker/webserver/**"
   pull_request:
     paths:
       - ".nvmrc"
@@ -21,6 +22,7 @@ on:
       - "src/*/static/**"
       - ".github/workflows/**"
       - ".github/scripts/**"
+      - "docker/webserver/**"
   workflow_dispatch: # Manually
 env:
   REGISTRY: ghcr.io/noaa-gsl/unified-graphics/ui

--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update \
     && apt-get install -y build-essential \
     && apt-get upgrade -y \
     && rm -rf /var/lib/apt/lists/*
-RUN poetry install --no-interaction --no-ansi --no-dev
+RUN poetry install --no-interaction --no-ansi --without dev
 
 RUN groupadd -g 1000 python && \
     useradd -r -u 1000 -g python python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,15 +24,13 @@ psycopg = {version = "^3.1.9", extras = ["binary", "pool"]}
 alembic = "^1.10.4"
 pyarrow = "^12.0.1"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 pytest = "^7.3"
 mypy = "^1.2"
 black = "^23.3.0"
 flake8 = "^6.0.0"
 coverage = "^7.2.3"
 isort = "^5.10.1"
-
-[tool.poetry.group.dev.dependencies]
 python-dotenv = "^1.0.0"
 pandas-stubs = "^2.0.2.230605"
 moto = {extras = ["server"], version = "^4.1.12"}


### PR DESCRIPTION
The `--dev` option is deprecated in favor of Poetry dependency groups. The Poetry CLI flag is also being updated so change our Docker images to use `--without dev` instead of the deprecated `--no-dev`.

This change also adds CI triggers for when our `pyproject.toml` file and `Dockerfile`'s are updated.