### PR TITLE
Update Dependabot to use the new repo structure

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,8 @@ updates:
       interval: "weekly"
     pull-request-branch-name:
       separator: "-" # Use "-" instead of "/" in branch names to avoid issues with docker registries
+    assignees:
+      - "ian-noaa"
 
   - package-ecosystem: "docker"
     directory: "/"
@@ -18,24 +20,31 @@ updates:
       interval: "weekly"
     pull-request-branch-name:
       separator: "-" # Use "-" instead of "/" in branch names to avoid issues with docker registries
+    assignees:
+      - "ian-noaa"
 
   - package-ecosystem: "pip"
-    directory: "/services/api"
+    directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
     pull-request-branch-name:
       separator: "-" # Use "-" instead of "/" in branch names to avoid issues with docker registries
-
-  - package-ecosystem: "pip"
-    directory: "/services/data"
-    schedule:
-      interval: "monthly"
-    pull-request-branch-name:
-      separator: "-" # Use "-" instead of "/" in branch names to avoid issues with docker registries
+    assignees:
+      - "ian-noaa"
+    groups:
+      all:
+        patterns:
+        - "*"
 
   - package-ecosystem: "npm"
-    directory: "/services/api"
+    directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
     pull-request-branch-name:
       separator: "-" # Use "-" instead of "/" in branch names to avoid issues with docker registries
+    assignees:
+      - "ian-noaa"
+    groups:
+      all:
+        patterns:
+        - "*"


### PR DESCRIPTION
Our repo was reorganized in merge commit 7258fe206230141ac4648d2a245e89bd68c22fcf. However, Dependabot wasn't updated to use the new repo structure. Fix that, add a default assignee for version updates and experiment with Dependabot's new "groups". Hopefully, grouping version updates will help keep the number of PRs from exploding.