### PR TITLE
Update dependabot group names

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,5 @@
 **/__pycache__/
 node_modules/
-/tmp
+**/tmp
 
 *.pyc

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,8 +32,11 @@ updates:
     assignees:
       - "ian-noaa"
     groups:
-      all:
+      pip-dependencies:
         patterns:
+        # Ideally, we could split this into dev and application dependencies.
+        # However, then we'd have to maintain our dependencies list here as
+        # well as in the pyproject.toml file.
         - "*"
 
   - package-ecosystem: "npm"
@@ -45,6 +48,6 @@ updates:
     assignees:
       - "ian-noaa"
     groups:
-      all:
+      npm-dependencies:
         patterns:
         - "*"


### PR DESCRIPTION
The group names are used in PR titles so make them more descriptive.

Additionally, update the `.dockerignore` file to exclude `tmp/` directories.