### PR TITLE
Optimize JSON responses

### DIFF
--- a/src/unified_graphics/diag.py
+++ b/src/unified_graphics/diag.py
@@ -374,7 +374,6 @@ def magnitude(dataset: pd.DataFrame) -> pd.DataFrame:
         "observation": np.linalg.norm,
         "longitude": "first",
         "latitude": "first",
-        "is_used": "first",
     })
 
 

--- a/src/unified_graphics/diag.py
+++ b/src/unified_graphics/diag.py
@@ -366,32 +366,16 @@ def wind(
 
     return data.to_dataframe()
 
-def magnitude(dataset: List[Observation]) -> Generator[Observation, None, None]:
-    for obs in dataset:
-        if isinstance(obs.adjusted, Vector):
-            adjusted = vector_magnitude(obs.adjusted.u, obs.adjusted.v)
-        else:
-            adjusted = abs(obs.adjusted)
 
-        if isinstance(obs.unadjusted, Vector):
-            unadjusted = vector_magnitude(obs.unadjusted.u, obs.unadjusted.v)
-        else:
-            unadjusted = abs(obs.unadjusted)
-
-        if isinstance(obs.observed, Vector):
-            observed = vector_magnitude(obs.observed.u, obs.observed.v)
-        else:
-            observed = abs(obs.observed)
-
-        yield Observation(
-            obs.variable,
-            obs.variable_type,
-            obs.loop,
-            adjusted=adjusted,
-            unadjusted=unadjusted,
-            observed=observed,
-            position=obs.position,
-        )
+def magnitude(dataset: pd.DataFrame) -> pd.DataFrame:
+    return dataset.groupby(level=0).aggregate({
+        "obs_minus_forecast_adjusted": np.linalg.norm,
+        "obs_minus_forecast_unadjusted": np.linalg.norm,
+        "observation": np.linalg.norm,
+        "longitude": "first",
+        "latitude": "first",
+        "is_used": "first",
+    })
 
 
 def get_model_run_list(

--- a/src/unified_graphics/diag.py
+++ b/src/unified_graphics/diag.py
@@ -349,7 +349,7 @@ def wind(
     initialization_time: str,
     loop: MinimLoop,
     filters: MultiDict,
-) -> List[Observation]:
+) -> pd.DataFrame | pd.Series:
     data = open_diagnostic(
         diag_zarr,
         model,
@@ -364,32 +364,7 @@ def wind(
 
     data = apply_filters(data, filters)
 
-    omf_adj_u = data["obs_minus_forecast_adjusted"].sel(component="u").values
-    omf_adj_v = data["obs_minus_forecast_adjusted"].sel(component="v").values
-    omf_una_u = data["obs_minus_forecast_unadjusted"].sel(component="u").values
-    omf_una_v = data["obs_minus_forecast_unadjusted"].sel(component="v").values
-    obs_u = data["observation"].sel(component="u").values
-    obs_v = data["observation"].sel(component="v").values
-    lng = data["longitude"].values
-    lat = data["latitude"].values
-
-    return [
-        Observation(
-            "wind",
-            VariableType.VECTOR,
-            loop,
-            adjusted=Vector(
-                round(float(omf_adj_u[idx]), 5), round(float(omf_adj_v[idx]), 5)
-            ),
-            unadjusted=Vector(
-                round(float(omf_una_u[idx]), 5), round(float(omf_una_v[idx]), 5)
-            ),
-            observed=Vector(round(float(obs_u[idx]), 5), round(float(obs_v[idx]), 5)),
-            position=Coordinate(round(float(lng[idx]), 5), round(float(lat[idx]), 5)),
-        )
-        for idx in range(data.dims["nobs"])
-    ]
-
+    return data.to_dataframe()
 
 def magnitude(dataset: List[Observation]) -> Generator[Observation, None, None]:
     for obs in dataset:

--- a/src/unified_graphics/diag.py
+++ b/src/unified_graphics/diag.py
@@ -226,7 +226,7 @@ def scalar(
     initialization_time: str,
     loop: MinimLoop,
     filters: MultiDict,
-) -> List[Observation]:
+) -> pd.DataFrame:
     data = open_diagnostic(
         diag_zarr,
         model,
@@ -240,22 +240,7 @@ def scalar(
     )
     data = apply_filters(data, filters)
 
-    return [
-        Observation(
-            variable.name.lower(),
-            VariableType.SCALAR,
-            loop,
-            adjusted=float(data["obs_minus_forecast_adjusted"].values[idx]),
-            unadjusted=float(data["obs_minus_forecast_unadjusted"].values[idx]),
-            observed=float(data["observation"].values[idx]),
-            position=Coordinate(
-                float(data["longitude"].values[idx]),
-                float(data["latitude"].values[idx]),
-            ),
-        )
-        for idx in range(data.dims["nobs"])
-    ]
-
+    return data.to_dataframe()
 
 def temperature(
     diag_zarr: str,
@@ -267,7 +252,7 @@ def temperature(
     initialization_time: str,
     loop: MinimLoop,
     filters: MultiDict,
-) -> List[Observation]:
+) -> pd.DataFrame:
     return scalar(
         diag_zarr,
         model,
@@ -292,7 +277,7 @@ def moisture(
     initialization_time: str,
     loop: MinimLoop,
     filters: MultiDict,
-) -> List[Observation]:
+) -> pd.DataFrame:
     return scalar(
         diag_zarr,
         model,
@@ -317,7 +302,7 @@ def pressure(
     initialization_time: str,
     loop: MinimLoop,
     filters: MultiDict,
-) -> List[Observation]:
+) -> pd.DataFrame:
     return scalar(
         diag_zarr,
         model,

--- a/src/unified_graphics/routes.py
+++ b/src/unified_graphics/routes.py
@@ -1,5 +1,3 @@
-import json
-
 from flask import (
     Blueprint,
     current_app,
@@ -180,13 +178,15 @@ def diagnostics(
         initialization_time,
         diag.MinimLoop(loop),
         request.args,
-    )[[
-        "obs_minus_forecast_adjusted",
-        "obs_minus_forecast_unadjusted",
-        "observation",
-        "longitude",
-        "latitude",
-    ]]
+    )[
+        [
+            "obs_minus_forecast_adjusted",
+            "obs_minus_forecast_unadjusted",
+            "observation",
+            "longitude",
+            "latitude",
+        ]
+    ]
 
     if "component" in data.index.names:
         data = data.unstack()
@@ -218,13 +218,15 @@ def magnitude(
         initialization_time,
         diag.MinimLoop(loop),
         request.args,
-    )[[
-        "obs_minus_forecast_adjusted",
-        "obs_minus_forecast_unadjusted",
-        "observation",
-        "longitude",
-        "latitude",
-    ]]
+    )[
+        [
+            "obs_minus_forecast_adjusted",
+            "obs_minus_forecast_unadjusted",
+            "observation",
+            "longitude",
+            "latitude",
+        ]
+    ]
     data = diag.magnitude(data)
 
     return data.to_json(orient="records"), {"Content-Type": "application/json"}

--- a/src/unified_graphics/routes.py
+++ b/src/unified_graphics/routes.py
@@ -202,20 +202,6 @@ def diagnostics(
 def magnitude(
     model, system, domain, background, frequency, variable, initialization_time, loop
 ):
-    def generate(df):
-        yield "["
-        for idx, obs in enumerate(df.itertuples()):
-            if idx > 0:
-                yield ","
-            yield json.dumps({
-                "obs_minus_forecast_adjusted": obs.obs_minus_forecast_adjusted,
-                "obs_minus_forecast_unadjusted": obs.obs_minus_forecast_unadjusted,
-                "observation": obs.observation,
-                "longitude": obs.longitude,
-                "latitude": obs.latitude,
-            })
-        yield "]"
-
     try:
         v = diag.Variable(variable)
     except ValueError:
@@ -232,7 +218,13 @@ def magnitude(
         initialization_time,
         diag.MinimLoop(loop),
         request.args,
-    )
+    )[[
+        "obs_minus_forecast_adjusted",
+        "obs_minus_forecast_unadjusted",
+        "observation",
+        "longitude",
+        "latitude",
+    ]]
     data = diag.magnitude(data)
 
-    return generate(data), {"Content-Type": "application/json"}
+    return data.to_json(orient="records"), {"Content-Type": "application/json"}

--- a/src/unified_graphics/routes.py
+++ b/src/unified_graphics/routes.py
@@ -219,6 +219,20 @@ def diagnostics(
 def magnitude(
     model, system, domain, background, frequency, variable, initialization_time, loop
 ):
+    def generate(df):
+        yield "["
+        for idx, obs in enumerate(df.itertuples()):
+            if idx > 0:
+                yield ","
+            yield json.dumps({
+                "obs_minus_forecast_adjusted": obs.obs_minus_forecast_adjusted,
+                "obs_minus_forecast_unadjusted": obs.obs_minus_forecast_unadjusted,
+                "observation": obs.observation,
+                "longitude": obs.longitude,
+                "latitude": obs.latitude,
+            })
+        yield "]"
+
     try:
         v = diag.Variable(variable)
     except ValueError:
@@ -238,8 +252,4 @@ def magnitude(
     )
     data = diag.magnitude(data)
 
-    response = jsonify(
-        {"type": "FeatureCollection", "features": [obs.to_geojson() for obs in data]}
-    )
-
-    return response
+    return generate(data), {"Content-Type": "application/json"}

--- a/src/unified_graphics/static/js/component/Chart2DHistogram.js
+++ b/src/unified_graphics/static/js/component/Chart2DHistogram.js
@@ -138,11 +138,9 @@ export default class Chart2DHistogram extends ChartElement {
   }
 
   set data(value) {
-    if (Array.isArray(value)) {
-      this.#data = value;
-    } else {
-      this.#data = value.features.map((d) => d.properties.adjusted);
-    }
+    this.#data = value.map((record) => {
+      return { u: record["obs_minus_forecast_adjusted_u"], v: record["obs_minus_forecast_adjusted_v"] };
+    });
 
     // FIXME: This is duplicated across all charts to ensure that they fire
     // this event. This event is used by the ColorRamp component so that it

--- a/src/unified_graphics/static/js/component/Chart2DHistogram.js
+++ b/src/unified_graphics/static/js/component/Chart2DHistogram.js
@@ -139,7 +139,10 @@ export default class Chart2DHistogram extends ChartElement {
 
   set data(value) {
     this.#data = value.map((record) => {
-      return { u: record["obs_minus_forecast_adjusted_u"], v: record["obs_minus_forecast_adjusted_v"] };
+      return {
+        u: record["obs_minus_forecast_adjusted_u"],
+        v: record["obs_minus_forecast_adjusted_v"],
+      };
     });
 
     // FIXME: This is duplicated across all charts to ensure that they fire

--- a/src/unified_graphics/static/js/component/ChartHistogram.js
+++ b/src/unified_graphics/static/js/component/ChartHistogram.js
@@ -116,7 +116,7 @@ export default class ChartHistogram extends ChartElement {
       case "src":
         fetch(newValue)
           .then((response) => response.json())
-          .then((data) => data.features.map((d) => d.properties.adjusted))
+          .then((data) => data.map((d) => d.obs_minus_forecast_adjusted))
           .then((data) => (this.data = data));
         break;
       default:

--- a/src/unified_graphics/static/js/component/ChartMap.js
+++ b/src/unified_graphics/static/js/component/ChartMap.js
@@ -149,7 +149,7 @@ export default class ChartMap extends ChartElement {
     if (!observations) return scaleQuantize().range(schemePurples[9]);
 
     /** @type number[] */
-    const [lower, upper] = extent(observations.features, (feature) =>
+    const [lower, upper] = extent(observations, (feature) =>
       get(feature, this.fill)
     );
 
@@ -203,7 +203,7 @@ export default class ChartMap extends ChartElement {
 
     if (!(borders || observations)) return;
 
-    this.#projection.fitSize([width, height], observations ?? borders);
+    this.#projection.fitSize([width, height], borders);
 
     const ctx = canvas.getContext("2d");
     if (!ctx) return;
@@ -230,9 +230,10 @@ export default class ChartMap extends ChartElement {
     const fill = this.scale;
     const radius = 2;
 
-    observations.features.forEach((feature) => {
+    console.log(observations);
+    observations.forEach((feature) => {
       const value = get(feature, fillProp);
-      const [x, y] = this.#projection(feature.geometry.coordinates);
+      const [x, y] = this.#projection([feature.longitude, feature.latitude]);
 
       ctx.save();
       ctx.fillStyle = fill(value);

--- a/src/unified_graphics/static/js/component/ChartMap.js
+++ b/src/unified_graphics/static/js/component/ChartMap.js
@@ -149,9 +149,7 @@ export default class ChartMap extends ChartElement {
     if (!observations) return scaleQuantize().range(schemePurples[9]);
 
     /** @type number[] */
-    const [lower, upper] = extent(observations, (feature) =>
-      get(feature, this.fill)
-    );
+    const [lower, upper] = extent(observations, (feature) => get(feature, this.fill));
 
     const isDiverging = lower / Math.abs(lower) !== upper / Math.abs(upper);
     const largestBound = Math.max(Math.abs(lower), Math.abs(upper));

--- a/src/unified_graphics/templates/layouts/diag.html
+++ b/src/unified_graphics/templates/layouts/diag.html
@@ -41,7 +41,7 @@
     <chart-container class="padding-2 radius-md bg-white shadow-1">
       <chart-map id="observations-{{ minim_loop }}"
         src="{{ map_url[minim_loop] }}"
-        fill="properties.adjusted"></chart-map>
+        fill="obs_minus_forecast_adjusted"></chart-map>
       <color-ramp slot="legend" for="observations-{{ minim_loop }}" class="font-ui-3xs" format="s"
         >Observation &minus; Forecast</color-ramp>
     </chart-container>

--- a/tests/test_diag.py
+++ b/tests/test_diag.py
@@ -234,40 +234,6 @@ def test_open_diagnostic_s3(moto_server, test_dataset, monkeypatch):
     xr.testing.assert_equal(result, expected)
 
 
-# Test cases taken from the examples at
-# http://ncl.ucar.edu/Document/Functions/Contributed/wind_direction.shtml
-@pytest.mark.parametrize(
-    "u,v,expected",
-    (
-        [
-            np.array([10, 0, 0, -10, 10, 10, -10, -10]),
-            np.array([0, 10, -10, 0, 10, -10, 10, -10]),
-            np.array([270, 180, 0, 90, 225, 315, 135, 45]),
-        ],
-        [
-            np.array([0.0, -0.0, 0.0, -0.0]),
-            np.array([0.0, 0.0, -0.0, -0.0]),
-            np.array([0.0, 0.0, 0.0, 0.0]),
-        ],
-    ),
-)
-def test_vector_direction(u, v, expected):
-    result = diag.vector_direction(u, v)
-
-    np.testing.assert_array_almost_equal(result, expected, decimal=5)
-
-
-def test_vector_magnitude():
-    u = np.array([1, 0, 1, 0])
-    v = np.array([0, 1, 1, 0])
-
-    result = diag.vector_magnitude(u, v)
-
-    np.testing.assert_array_almost_equal(
-        result, np.array([1, 1, 1.41421, 0]), decimal=5
-    )
-
-
 @pytest.mark.parametrize(
     "mapping,expected",
     [

--- a/tests/test_unified_graphics.py
+++ b/tests/test_unified_graphics.py
@@ -374,9 +374,9 @@ def test_range_filter_vector(uv, client):
     # Assert
     assert response.json == [
         {
-            "adjusted": {"u": 0.0, "v": 1.0},
-            "unadjusted": {"u": 0.0, "v": 1.0},
-            "observed": {"u": 0.0, "v": 1.0},
+            "obs_minus_forecast_adjusted": {"u": 0.0, "v": 1.0},
+            "obs_minus_forecast_unadjusted": {"u": 0.0, "v": 1.0},
+            "observation": {"u": 0.0, "v": 1.0},
             "longitude": 90.0,
             "latitude": 22.0,
         },

--- a/tests/test_unified_graphics.py
+++ b/tests/test_unified_graphics.py
@@ -115,9 +115,22 @@ def test_scalar_diag(t, client):
 
     # Assert
     assert response.json == [
-        {"obs_minus_forecast_adjusted": 1.0, "obs_minus_forecast_unadjusted": 1.0, "observation": 1.0, "longitude": 90.0, "latitude": 22.0},
-        {"obs_minus_forecast_adjusted": -1.0, "obs_minus_forecast_unadjusted": -1.0, "observation": 0.0, "longitude": 91.0, "latitude": 23.0},
+        {
+            "obs_minus_forecast_adjusted": 1.0,
+            "obs_minus_forecast_unadjusted": 1.0,
+            "observation": 1.0,
+            "longitude": 90.0,
+            "latitude": 22.0,
+        },
+        {
+            "obs_minus_forecast_adjusted": -1.0,
+            "obs_minus_forecast_unadjusted": -1.0,
+            "observation": 0.0,
+            "longitude": 91.0,
+            "latitude": 23.0,
+        },
     ]
+
 
 def test_scalar_history(model, diag_parquet, client, test_dataset):
     # Arrange
@@ -300,8 +313,20 @@ def test_vector_magnitude(uv, client):
 
     # Assert
     assert response.json == [
-        {"obs_minus_forecast_adjusted": 1.0, "obs_minus_forecast_unadjusted": 1.0, "observation": 1.0, "longitude": 90.0, "latitude": 22.0},
-        {"obs_minus_forecast_adjusted": 1.0, "obs_minus_forecast_unadjusted": 1.0, "observation": 1.0, "longitude": 91.0, "latitude": 23.0},
+        {
+            "obs_minus_forecast_adjusted": 1.0,
+            "obs_minus_forecast_unadjusted": 1.0,
+            "observation": 1.0,
+            "longitude": 90.0,
+            "latitude": 22.0,
+        },
+        {
+            "obs_minus_forecast_adjusted": 1.0,
+            "obs_minus_forecast_unadjusted": 1.0,
+            "observation": 1.0,
+            "longitude": 91.0,
+            "latitude": 23.0,
+        },
     ]
 
 
@@ -318,7 +343,7 @@ def test_region_filter_scalar(t, client):
             "obs_minus_forecast_unadjusted": 1.0,
             "observation": 1.0,
             "longitude": 90.0,
-            "latitude": 22.0
+            "latitude": 22.0,
         },
     ]
 

--- a/tests/test_unified_graphics.py
+++ b/tests/test_unified_graphics.py
@@ -114,36 +114,10 @@ def test_scalar_diag(t, client):
     response = client.get(f"/diag/{group}/")
 
     # Assert
-    assert response.json == {
-        "type": "FeatureCollection",
-        "features": [
-            {
-                "type": "Feature",
-                "properties": {
-                    "type": "scalar",
-                    "loop": t.loop,
-                    "variable": "temperature",
-                    "adjusted": 1.0,
-                    "unadjusted": 1.0,
-                    "observed": 1.0,
-                },
-                "geometry": {"type": "Point", "coordinates": [90.0, 22.0]},
-            },
-            {
-                "type": "Feature",
-                "properties": {
-                    "type": "scalar",
-                    "loop": t.loop,
-                    "variable": "temperature",
-                    "adjusted": -1.0,
-                    "unadjusted": -1.0,
-                    "observed": 0.0,
-                },
-                "geometry": {"type": "Point", "coordinates": [91.0, 23.0]},
-            },
-        ],
-    }
-
+    assert response.json == [
+        {"obs_minus_forecast_adjusted": 1.0, "obs_minus_forecast_unadjusted": 1.0, "observation": 1.0, "longitude": 90.0, "latitude": 22.0},
+        {"obs_minus_forecast_adjusted": -1.0, "obs_minus_forecast_unadjusted": -1.0, "observation": 0.0, "longitude": 91.0, "latitude": 23.0},
+    ]
 
 def test_scalar_history(model, diag_parquet, client, test_dataset):
     # Arrange
@@ -289,35 +263,10 @@ def test_wind_diag(uv, client):
     response = client.get(f"/diag/{group}/")
 
     # Assert
-    assert response.json == {
-        "type": "FeatureCollection",
-        "features": [
-            {
-                "type": "Feature",
-                "properties": {
-                    "type": "vector",
-                    "variable": "wind",
-                    "loop": "ges",
-                    "adjusted": {"u": 0.0, "v": 1.0},
-                    "unadjusted": {"u": 0.0, "v": 1.0},
-                    "observed": {"u": 0.0, "v": 1.0},
-                },
-                "geometry": {"type": "Point", "coordinates": [90, 22]},
-            },
-            {
-                "type": "Feature",
-                "properties": {
-                    "type": "vector",
-                    "variable": "wind",
-                    "loop": "ges",
-                    "adjusted": {"u": 0.0, "v": -1.0},
-                    "unadjusted": {"u": 0.0, "v": -1.0},
-                    "observed": {"u": 1.0, "v": 0.0},
-                },
-                "geometry": {"type": "Point", "coordinates": [91.0, 23.0]},
-            },
-        ],
-    }
+    assert response.json == [
+        {"obs_minus_forecast_adjusted": {"u": 0.0, "v": 1.0}, "obs_minus_forecast_unadjusted": {"u": 0.0, "v": 1.0}, "observation": {"u": 0.0, "v": 1.0}, "longitude": 90.0, "latitude": 22.0},
+        {"obs_minus_forecast_adjusted": {"u": 0.0, "v": -1.0}, "obs_minus_forecast_unadjusted": {"u": 0.0, "v": -1.0}, "observation": {"u": 1.0, "v": 0.0}, "longitude": 91.0, "latitude": 23.0},
+    ]
 
 
 def test_vector_magnitude(uv, client):
@@ -328,35 +277,10 @@ def test_vector_magnitude(uv, client):
     response = client.get(f"/diag/{group}/magnitude/")
 
     # Assert
-    assert response.json == {
-        "type": "FeatureCollection",
-        "features": [
-            {
-                "type": "Feature",
-                "properties": {
-                    "type": "vector",
-                    "variable": "wind",
-                    "loop": "ges",
-                    "adjusted": 1.0,
-                    "unadjusted": 1.0,
-                    "observed": 1.0,
-                },
-                "geometry": {"type": "Point", "coordinates": [90.0, 22.0]},
-            },
-            {
-                "type": "Feature",
-                "properties": {
-                    "type": "vector",
-                    "variable": "wind",
-                    "loop": "ges",
-                    "adjusted": 1.0,
-                    "unadjusted": 1.0,
-                    "observed": 1.0,
-                },
-                "geometry": {"type": "Point", "coordinates": [91.0, 23.0]},
-            },
-        ],
-    }
+    assert response.json == [
+        {"obs_minus_forecast_adjusted": 1.0, "obs_minus_forecast_unadjusted": 1.0, "observation": 1.0, "longitude": 90.0, "latitude": 22.0},
+        {"obs_minus_forecast_adjusted": 1.0, "obs_minus_forecast_unadjusted": 1.0, "observation": 1.0, "longitude": 91.0, "latitude": 23.0},
+    ]
 
 
 def test_region_filter_scalar(t, client):
@@ -366,23 +290,15 @@ def test_region_filter_scalar(t, client):
     query = "longitude=89.9::90.5&latitude=27::22"
     response = client.get(f"{url}?{query}")
 
-    assert response.json == {
-        "type": "FeatureCollection",
-        "features": [
-            {
-                "type": "Feature",
-                "properties": {
-                    "type": "scalar",
-                    "loop": "ges",
-                    "variable": "temperature",
-                    "adjusted": 1.0,
-                    "unadjusted": 1.0,
-                    "observed": 1.0,
-                },
-                "geometry": {"type": "Point", "coordinates": [90.0, 22.0]},
-            },
-        ],
-    }
+    assert response.json == [
+        {
+            "obs_minus_forecast_adjusted": 1.0,
+            "obs_minus_forecast_unadjusted": 1.0,
+            "observation": 1.0,
+            "longitude": 90.0,
+            "latitude": 22.0
+        },
+    ]
 
 
 def test_range_filter_scalar(t, client):
@@ -395,23 +311,15 @@ def test_range_filter_scalar(t, client):
     response = client.get(f"{url}?{query}")
 
     # Assert
-    assert response.json == {
-        "type": "FeatureCollection",
-        "features": [
-            {
-                "type": "Feature",
-                "properties": {
-                    "type": "scalar",
-                    "loop": t.loop,
-                    "variable": "temperature",
-                    "adjusted": 1.0,
-                    "unadjusted": 1.0,
-                    "observed": 1.0,
-                },
-                "geometry": {"type": "Point", "coordinates": [90.0, 22.0]},
-            },
-        ],
-    }
+    assert response.json == [
+        {
+            "obs_minus_forecast_adjusted": 1.0,
+            "obs_minus_forecast_unadjusted": 1.0,
+            "observation": 1.0,
+            "longitude": 90.0,
+            "latitude": 22.0,
+        },
+    ]
 
 
 def test_region_filter_vector(uv, client):
@@ -423,23 +331,15 @@ def test_region_filter_vector(uv, client):
     # Act
     response = client.get(f"{url}?{query}")
 
-    assert response.json == {
-        "type": "FeatureCollection",
-        "features": [
-            {
-                "type": "Feature",
-                "properties": {
-                    "type": "vector",
-                    "variable": "wind",
-                    "loop": uv.loop,
-                    "adjusted": {"u": 0.0, "v": 1.0},
-                    "unadjusted": {"u": 0.0, "v": 1.0},
-                    "observed": {"u": 0.0, "v": 1.0},
-                },
-                "geometry": {"type": "Point", "coordinates": [90.0, 22.0]},
-            },
-        ],
-    }
+    assert response.json == [
+        {
+            "obs_minus_forecast_adjusted": {"u": 0.0, "v": 1.0},
+            "obs_minus_forecast_unadjusted": {"u": 0.0, "v": 1.0},
+            "observation": {"u": 0.0, "v": 1.0},
+            "longitude": 90.0,
+            "latitude": 22.0
+        },
+    ]
 
 
 # BUG: This test is missing a test case
@@ -472,23 +372,15 @@ def test_range_filter_vector(uv, client):
     response = client.get(f"{url}?{query}")
 
     # Assert
-    assert response.json == {
-        "type": "FeatureCollection",
-        "features": [
-            {
-                "type": "Feature",
-                "properties": {
-                    "type": "vector",
-                    "variable": "wind",
-                    "loop": uv.loop,
-                    "adjusted": {"u": 0.0, "v": 1.0},
-                    "unadjusted": {"u": 0.0, "v": 1.0},
-                    "observed": {"u": 0.0, "v": 1.0},
-                },
-                "geometry": {"type": "Point", "coordinates": [90.0, 22.0]},
-            },
-        ],
-    }
+    assert response.json == [
+        {
+            "adjusted": {"u": 0.0, "v": 1.0},
+            "unadjusted": {"u": 0.0, "v": 1.0},
+            "observed": {"u": 0.0, "v": 1.0},
+            "longitude": 90.0,
+            "latitude": 22.0,
+        },
+    ]
 
 
 def test_unused_filter(t, client):
@@ -501,23 +393,15 @@ def test_unused_filter(t, client):
     response = client.get(f"{url}?{query}")
 
     # Assert
-    assert response.json == {
-        "type": "FeatureCollection",
-        "features": [
-            {
-                "type": "Feature",
-                "properties": {
-                    "type": "scalar",
-                    "loop": t.loop,
-                    "variable": "temperature",
-                    "adjusted": 3.0,
-                    "unadjusted": 3.0,
-                    "observed": 2.0,
-                },
-                "geometry": {"type": "Point", "coordinates": [89.0, 24.0]},
-            },
-        ],
-    }
+    assert response.json == [
+        {
+            "obs_minus_forecast_adjusted": 3.0,
+            "obs_minus_forecast_unadjusted": 3.0,
+            "observation": 2.0,
+            "longitude": 89.0,
+            "latitude": 24.0,
+        },
+    ]
 
 
 def test_all_obs_filter(t, client):
@@ -528,47 +412,29 @@ def test_all_obs_filter(t, client):
     response = client.get(f"{url}?{query}")
 
     assert response.status_code == 200
-    assert response.json == {
-        "type": "FeatureCollection",
-        "features": [
-            {
-                "type": "Feature",
-                "properties": {
-                    "type": "scalar",
-                    "loop": t.loop,
-                    "variable": "temperature",
-                    "adjusted": 1.0,
-                    "unadjusted": 1.0,
-                    "observed": 1.0,
-                },
-                "geometry": {"type": "Point", "coordinates": [90.0, 22.0]},
-            },
-            {
-                "type": "Feature",
-                "properties": {
-                    "type": "scalar",
-                    "loop": t.loop,
-                    "variable": "temperature",
-                    "adjusted": -1.0,
-                    "unadjusted": -1.0,
-                    "observed": 0.0,
-                },
-                "geometry": {"type": "Point", "coordinates": [91.0, 23.0]},
-            },
-            {
-                "type": "Feature",
-                "properties": {
-                    "type": "scalar",
-                    "loop": t.loop,
-                    "variable": "temperature",
-                    "adjusted": 3.0,
-                    "unadjusted": 3.0,
-                    "observed": 2.0,
-                },
-                "geometry": {"type": "Point", "coordinates": [89.0, 24.0]},
-            },
-        ],
-    }
+    assert response.json == [
+        {
+            "obs_minus_forecast_adjusted": 1.0,
+            "obs_minus_forecast_unadjusted": 1.0,
+            "observation": 1.0,
+            "longitude": 90.0,
+            "latitude": 22.0,
+        },
+        {
+            "obs_minus_forecast_adjusted": -1.0,
+            "obs_minus_forecast_unadjusted": -1.0,
+            "observation": 0.0,
+            "longitude": 91.0,
+            "latitude": 23.0,
+        },
+        {
+            "obs_minus_forecast_adjusted": 3.0,
+            "obs_minus_forecast_unadjusted": 3.0,
+            "observation": 2.0,
+            "longitude": 89.0,
+            "latitude": 24.0,
+        },
+    ]
 
 
 @pytest.mark.parametrize("variable", ["t", "q", "ps", "uv"])

--- a/tests/test_unified_graphics.py
+++ b/tests/test_unified_graphics.py
@@ -264,8 +264,30 @@ def test_wind_diag(uv, client):
 
     # Assert
     assert response.json == [
-        {"obs_minus_forecast_adjusted": {"u": 0.0, "v": 1.0}, "obs_minus_forecast_unadjusted": {"u": 0.0, "v": 1.0}, "observation": {"u": 0.0, "v": 1.0}, "longitude": 90.0, "latitude": 22.0},
-        {"obs_minus_forecast_adjusted": {"u": 0.0, "v": -1.0}, "obs_minus_forecast_unadjusted": {"u": 0.0, "v": -1.0}, "observation": {"u": 1.0, "v": 0.0}, "longitude": 91.0, "latitude": 23.0},
+        {
+            "obs_minus_forecast_adjusted_u": 0.0,
+            "obs_minus_forecast_adjusted_v": 1.0,
+            "obs_minus_forecast_unadjusted_u": 0.0,
+            "obs_minus_forecast_unadjusted_v": 1.0,
+            "observation_u": 0.0,
+            "observation_v": 1.0,
+            "longitude_u": 90.0,
+            "longitude_v": 90.0,
+            "latitude_u": 22.0,
+            "latitude_v": 22.0,
+        },
+        {
+            "obs_minus_forecast_adjusted_u": 0.0,
+            "obs_minus_forecast_adjusted_v": -1.0,
+            "obs_minus_forecast_unadjusted_u": 0.0,
+            "obs_minus_forecast_unadjusted_v": -1.0,
+            "observation_u": 1.0,
+            "observation_v": 0.0,
+            "longitude_u": 91.0,
+            "longitude_v": 91.0,
+            "latitude_u": 23.0,
+            "latitude_v": 23.0,
+        },
     ]
 
 
@@ -333,11 +355,16 @@ def test_region_filter_vector(uv, client):
 
     assert response.json == [
         {
-            "obs_minus_forecast_adjusted": {"u": 0.0, "v": 1.0},
-            "obs_minus_forecast_unadjusted": {"u": 0.0, "v": 1.0},
-            "observation": {"u": 0.0, "v": 1.0},
-            "longitude": 90.0,
-            "latitude": 22.0
+            "obs_minus_forecast_adjusted_u": 0.0,
+            "obs_minus_forecast_adjusted_v": 1.0,
+            "obs_minus_forecast_unadjusted_u": 0.0,
+            "obs_minus_forecast_unadjusted_v": 1.0,
+            "observation_u": 0.0,
+            "observation_v": 1.0,
+            "longitude_u": 90.0,
+            "longitude_v": 90.0,
+            "latitude_u": 22.0,
+            "latitude_v": 22.0,
         },
     ]
 
@@ -374,11 +401,16 @@ def test_range_filter_vector(uv, client):
     # Assert
     assert response.json == [
         {
-            "obs_minus_forecast_adjusted": {"u": 0.0, "v": 1.0},
-            "obs_minus_forecast_unadjusted": {"u": 0.0, "v": 1.0},
-            "observation": {"u": 0.0, "v": 1.0},
-            "longitude": 90.0,
-            "latitude": 22.0,
+            "obs_minus_forecast_adjusted_u": 0.0,
+            "obs_minus_forecast_adjusted_v": 1.0,
+            "obs_minus_forecast_unadjusted_u": 0.0,
+            "obs_minus_forecast_unadjusted_v": 1.0,
+            "observation_u": 0.0,
+            "observation_v": 1.0,
+            "longitude_u": 90.0,
+            "longitude_v": 90.0,
+            "latitude_u": 22.0,
+            "latitude_v": 22.0,
         },
     ]
 


### PR DESCRIPTION
Optimize the backend that generates the JSON from the Zarr and Parquet files. All of the list comprehensions in Python that were generating the GeoJSON responses were really slowing down our responses. By changing the response format and relying on `pandas.DataFrame.to_json` so that we can eliminate those loops, we get significantly faster responses (0.3s instead of 20s).