### PR TITLE
Fix Trivy CI failures

### DIFF
--- a/.github/workflows/api.yaml
+++ b/.github/workflows/api.yaml
@@ -174,6 +174,7 @@ jobs:
           output: "trivy-results.sarif"
           ignore-unfixed: true
           severity: "CRITICAL,HIGH"
+          limit-severities-for-sarif: true
           exit-code: "1"
         env:
           TRIVY_USERNAME: ${{ github.actor }}
@@ -198,6 +199,7 @@ jobs:
           output: "trivy-results.sarif"
           ignore-unfixed: true
           severity: "CRITICAL,HIGH"
+          limit-severities-for-sarif: true
           exit-code: "1"
         env:
           TRIVY_USERNAME: ${{ github.actor }}

--- a/.github/workflows/api.yaml
+++ b/.github/workflows/api.yaml
@@ -167,7 +167,7 @@ jobs:
       - name: Extract branch/tag name
         run: python3 ./.github/scripts/extract_git_ref.py # Provides env.BRANCH
       - name: Scan image with Trivy
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@0.14.0
         with:
           image-ref: "${{ env.REGISTRY }}/api:${{ env.BRANCH }}"
           format: "sarif"
@@ -191,7 +191,7 @@ jobs:
       - name: Extract branch/tag name
         run: python3 ./.github/scripts/extract_git_ref.py # Provides env.BRANCH
       - name: Scan image with Trivy
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@0.14.0
         with:
           image-ref: "${{ env.REGISTRY }}/data:${{ env.BRANCH }}"
           format: "sarif"

--- a/.github/workflows/ui.yaml
+++ b/.github/workflows/ui.yaml
@@ -109,7 +109,7 @@ jobs:
       - name: Extract branch/tag name
         run: python3 ./.github/scripts/extract_git_ref.py # Provides env.BRANCH
       - name: Scan image with Trivy
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@0.14.0
         with:
           image-ref: "${{ env.REGISTRY }}:${{ env.BRANCH }}"
           format: "sarif"

--- a/.github/workflows/ui.yaml
+++ b/.github/workflows/ui.yaml
@@ -116,6 +116,7 @@ jobs:
           output: "trivy-results.sarif"
           ignore-unfixed: true
           severity: "CRITICAL,HIGH"
+          limit-severities-for-sarif: true
           exit-code: "1"
         env:
           TRIVY_USERNAME: ${{ github.actor }}


### PR DESCRIPTION
Now that we have dependabot to keep our GitHub Actions up-to-date, switch to using a specific Trivy release. 

Additionally, the latest Trivy release fixed a bug that was hiding a misconfiguration in our pipelines. For some reason, the GitHub Action Trivy publishes has decided to diverge from its CLI tool's behavior and ignore the `severity: CRITICAL,HIGH` configuration unless the `limit-severities-for-sarif: true` option is also set. When coupled with the `exit-code: 1` config option we had set, this meant Trivy would exit with an error code of 1 when it found any vulnerability, not just a critical or high vulnerability like we were anticipating.