### PR TITLE
Limit time series display to 2 weeks

### DIFF
--- a/src/unified_graphics/diag.py
+++ b/src/unified_graphics/diag.py
@@ -351,8 +351,8 @@ def history(
         filters=(
             ("loop", "=", loop.value),
             ("is_used", "=", True),
-            ("initialization_time", ">=", start.isoformat()),
-            ("initialization_time", "<=", initialization_time.isoformat()),
+            ("initialization_time", ">=", start),
+            ("initialization_time", "<=", initialization_time),
         ),
     )
 

--- a/src/unified_graphics/diag.py
+++ b/src/unified_graphics/diag.py
@@ -1,5 +1,6 @@
 import os
 from collections import namedtuple
+from datetime import datetime, timedelta
 from enum import Enum
 from typing import Union
 from urllib.parse import urlparse
@@ -334,6 +335,7 @@ def history(
     frequency: str,
     variable: Variable,
     loop: MinimLoop,
+    initialization_time: datetime,
     filters: MultiDict,
 ) -> pd.DataFrame:
     parquet_file = os.path.join(
@@ -342,10 +344,16 @@ def history(
         variable.value,
     )
 
+    start = initialization_time - timedelta(weeks=2)
     df = pd.read_parquet(
         parquet_file,
         columns=["initialization_time", "obs_minus_forecast_unadjusted"],
-        filters=(("loop", "=", loop.value), ("is_used", "=", True)),
+        filters=(
+            ("loop", "=", loop.value),
+            ("is_used", "=", True),
+            ("initialization_time", ">=", start.isoformat()),
+            ("initialization_time", "<=", initialization_time.isoformat()),
+        ),
     )
 
     if df.empty:

--- a/src/unified_graphics/routes.py
+++ b/src/unified_graphics/routes.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+
 from flask import (
     Blueprint,
     current_app,

--- a/src/unified_graphics/routes.py
+++ b/src/unified_graphics/routes.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from flask import (
     Blueprint,
     current_app,
@@ -138,6 +139,8 @@ def serviceworker():
 
 @bp.route("/diag/<model>/<system>/<domain>/<background>/<frequency>/<variable>/<loop>/")
 def history(model, system, domain, background, frequency, variable, loop):
+    args = request.args.copy()
+    initialization_time = datetime.fromisoformat(args.pop("initialization_time"))
     data = diag.history(
         current_app.config["DIAG_PARQUET"],
         model,
@@ -147,7 +150,8 @@ def history(model, system, domain, background, frequency, variable, loop):
         frequency,
         diag.Variable(variable),
         diag.MinimLoop(loop),
-        request.args,
+        initialization_time,
+        args,
     )
 
     return data.to_json(orient="records", date_format="iso"), {

--- a/src/unified_graphics/templates/layouts/diag.html
+++ b/src/unified_graphics/templates/layouts/diag.html
@@ -31,7 +31,7 @@
 
         <chart-container class="padding-2 radius-md bg-white shadow-1">
           <span class="axis-y title" slot="title-y">Observation &minus; Forecast</span>
-          <chart-timeseries id="history-{{ minim_loop }}" src="{{ history_url[minim_loop] }}"
+          <chart-timeseries id="history-{{ minim_loop }}" src="{{ history_url[minim_loop] }}?initialization_time={{ form.get("initialization_time") }}"
             current="{{ form.get("initialization_time") }}"></chart-timeseries>
           <span class="axis-x title" slot="title-x">Initialization Time</span>
         </chart-container>

--- a/tests/test_diag.py
+++ b/tests/test_diag.py
@@ -1,4 +1,5 @@
 import uuid
+from datetime import datetime
 from functools import partial
 
 import numpy as np
@@ -303,6 +304,7 @@ def test_history(tmp_path, test_dataset, diag_parquet):
         "REALTIME",
         diag.Variable.PRESSURE,
         diag.MinimLoop.GUESS,
+        datetime.fromisoformat(run_list[1]["initialization_time"]),
         MultiDict(),
     )
 
@@ -387,6 +389,7 @@ def test_history_s3(aws_credentials, moto_server, s3_client, test_dataset, monke
         "REALTIME",
         diag.Variable.PRESSURE,
         diag.MinimLoop.GUESS,
+        datetime.fromisoformat(run_list[0]["initialization_time"]),
         MultiDict(),
     )
 
@@ -394,14 +397,14 @@ def test_history_s3(aws_credentials, moto_server, s3_client, test_dataset, monke
         result,
         pd.DataFrame(
             {
-                "initialization_time": ["2022-05-16T04:00", "2022-05-16T07:00"],
-                "min": [5.0, -5.0],
-                "25%": [6.5, -3.0],
-                "50%": [7.5, -3.0],
-                "75%": [8.5, -3.0],
-                "max": [10.0, -2.0],
-                "mean": [7.5, -3.2],
-                "count": [4.0, 5.0],
+                "initialization_time": ["2022-05-16T04:00"],
+                "min": [5.0],
+                "25%": [6.5],
+                "50%": [7.5],
+                "75%": [8.5],
+                "max": [10.0],
+                "mean": [7.5],
+                "count": [4.0],
             }
         ),
     )

--- a/tests/test_diag.py
+++ b/tests/test_diag.py
@@ -312,7 +312,9 @@ def test_history(tmp_path, test_dataset, diag_parquet):
         result,
         pd.DataFrame(
             {
-                "initialization_time": np.array([r["initialization_time"] for r in run_list], dtype="datetime64[us]"),
+                "initialization_time": np.array(
+                    [r["initialization_time"] for r in run_list], dtype="datetime64[us]"
+                ),
                 "min": [5.0, -5.0],
                 "25%": [6.5, -3.0],
                 "50%": [7.5, -3.0],
@@ -339,7 +341,7 @@ def test_history_s3(aws_credentials, moto_server, s3_client, test_dataset, monke
 
     run_list = [
         {
-            "initialization_time": datetime.fromisoformat( "2022-05-16T04:00"),
+            "initialization_time": datetime.fromisoformat("2022-05-16T04:00"),
             "observation": [10, 14, 18, 20],
             "forecast_unadjusted": [5, 7, 10, 10],
             "longitude": [0, 0, 0, 0],
@@ -348,7 +350,7 @@ def test_history_s3(aws_credentials, moto_server, s3_client, test_dataset, monke
             # O - F [5, 7, 8, 10]
         },
         {
-            "initialization_time": datetime.fromisoformat( "2022-05-16T07:00"),
+            "initialization_time": datetime.fromisoformat("2022-05-16T07:00"),
             "observation": [1, 2, 3, 4, 5],
             "forecast_unadjusted": [3, 5, 6, 7, 10],
             "longitude": [0, 0, 0, 0, 0],
@@ -397,7 +399,9 @@ def test_history_s3(aws_credentials, moto_server, s3_client, test_dataset, monke
         result,
         pd.DataFrame(
             {
-                "initialization_time": np.array(["2022-05-16T04:00"], dtype="datetime64[us]"),
+                "initialization_time": np.array(
+                    ["2022-05-16T04:00"], dtype="datetime64[us]"
+                ),
                 "min": [5.0],
                 "25%": [6.5],
                 "50%": [7.5],

--- a/tests/test_diag.py
+++ b/tests/test_diag.py
@@ -263,7 +263,7 @@ class TestGetBounds:
 def test_history(tmp_path, test_dataset, diag_parquet):
     run_list = [
         {
-            "initialization_time": "2022-05-16T04:00",
+            "initialization_time": datetime.fromisoformat("2022-05-16T04:00"),
             "observation": [10, 14, 18, 20],
             "forecast_unadjusted": [5, 7, 10, 10],
             "longitude": [0, 0, 0, 0],
@@ -272,7 +272,7 @@ def test_history(tmp_path, test_dataset, diag_parquet):
             # O - F [5, 7, 8, 10]
         },
         {
-            "initialization_time": "2022-05-16T07:00",
+            "initialization_time": datetime.fromisoformat("2022-05-16T07:00"),
             "observation": [1, 2, 3, 4, 5],
             "forecast_unadjusted": [3, 5, 6, 7, 10],
             "longitude": [0, 0, 0, 0, 0],
@@ -304,7 +304,7 @@ def test_history(tmp_path, test_dataset, diag_parquet):
         "REALTIME",
         diag.Variable.PRESSURE,
         diag.MinimLoop.GUESS,
-        datetime.fromisoformat(run_list[1]["initialization_time"]),
+        run_list[1]["initialization_time"],
         MultiDict(),
     )
 
@@ -312,7 +312,7 @@ def test_history(tmp_path, test_dataset, diag_parquet):
         result,
         pd.DataFrame(
             {
-                "initialization_time": ["2022-05-16T04:00", "2022-05-16T07:00"],
+                "initialization_time": np.array([r["initialization_time"] for r in run_list], dtype="datetime64[us]"),
                 "min": [5.0, -5.0],
                 "25%": [6.5, -3.0],
                 "50%": [7.5, -3.0],
@@ -339,7 +339,7 @@ def test_history_s3(aws_credentials, moto_server, s3_client, test_dataset, monke
 
     run_list = [
         {
-            "initialization_time": "2022-05-16T04:00",
+            "initialization_time": datetime.fromisoformat( "2022-05-16T04:00"),
             "observation": [10, 14, 18, 20],
             "forecast_unadjusted": [5, 7, 10, 10],
             "longitude": [0, 0, 0, 0],
@@ -348,7 +348,7 @@ def test_history_s3(aws_credentials, moto_server, s3_client, test_dataset, monke
             # O - F [5, 7, 8, 10]
         },
         {
-            "initialization_time": "2022-05-16T07:00",
+            "initialization_time": datetime.fromisoformat( "2022-05-16T07:00"),
             "observation": [1, 2, 3, 4, 5],
             "forecast_unadjusted": [3, 5, 6, 7, 10],
             "longitude": [0, 0, 0, 0, 0],
@@ -389,7 +389,7 @@ def test_history_s3(aws_credentials, moto_server, s3_client, test_dataset, monke
         "REALTIME",
         diag.Variable.PRESSURE,
         diag.MinimLoop.GUESS,
-        datetime.fromisoformat(run_list[0]["initialization_time"]),
+        run_list[0]["initialization_time"],
         MultiDict(),
     )
 
@@ -397,7 +397,7 @@ def test_history_s3(aws_credentials, moto_server, s3_client, test_dataset, monke
         result,
         pd.DataFrame(
             {
-                "initialization_time": ["2022-05-16T04:00"],
+                "initialization_time": np.array(["2022-05-16T04:00"], dtype="datetime64[us]"),
                 "min": [5.0],
                 "25%": [6.5],
                 "50%": [7.5],

--- a/tests/test_unified_graphics.py
+++ b/tests/test_unified_graphics.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from pathlib import Path
 
 import pytest  # noqa: F401
@@ -136,14 +137,14 @@ def test_scalar_history(model, diag_parquet, client, test_dataset):
     # Arrange
     run_list = [
         {
-            "initialization_time": "2022-05-16T04:00",
+            "initialization_time": datetime.fromisoformat("2022-05-16T04:00"),
             "observation": [10, 20],
             "forecast_unadjusted": [5, 10],
             "is_used": [True, True],
             # O - F [5, 10]
         },
         {
-            "initialization_time": "2022-05-16T07:00",
+            "initialization_time": datetime.fromisoformat("2022-05-16T07:00"),
             "observation": [1, 2, 3],
             "forecast_unadjusted": [5, 10, 3],
             "longitude": [0, 0, 0],
@@ -168,7 +169,7 @@ def test_scalar_history(model, diag_parquet, client, test_dataset):
     # Assert
     assert response.json == [
         {
-            "initialization_time": "2022-05-16T04:00",
+            "initialization_time": "2022-05-16T04:00:00.000",
             "min": 5.0,
             "25%": 6.25,
             "50%": 7.5,
@@ -184,14 +185,14 @@ def test_scalar_history_unused(model, diag_parquet, client, test_dataset):
     # Arrange
     run_list = [
         {
-            "initialization_time": "2022-05-16T04:00",
+            "initialization_time": datetime.fromisoformat("2022-05-16T04:00"),
             "observation": [10, 20],
             "forecast_unadjusted": [5, 10],
             "is_used": [True, False],
             # O - F [5, 10]
         },
         {
-            "initialization_time": "2022-05-16T07:00",
+            "initialization_time": datetime.fromisoformat("2022-05-16T07:00"),
             "observation": [1, 2],
             "forecast_unadjusted": [5, 10],
             "is_used": [False, True],
@@ -214,7 +215,7 @@ def test_scalar_history_unused(model, diag_parquet, client, test_dataset):
     # Assert
     assert response.json == [
         {
-            "initialization_time": "2022-05-16T04:00",
+            "initialization_time": "2022-05-16T04:00:00.000",
             "min": 5.0,
             "25%": 5.0,
             "50%": 5.0,
@@ -224,7 +225,7 @@ def test_scalar_history_unused(model, diag_parquet, client, test_dataset):
             "count": 1.0,
         },
         {
-            "initialization_time": "2022-05-16T07:00",
+            "initialization_time": "2022-05-16T07:00:00.000",
             "min": -8.0,
             "25%": -8.0,
             "50%": -8.0,
@@ -240,11 +241,11 @@ def test_scalar_history_empty(model, diag_parquet, test_dataset, client):
     # Arrange
     run_list = [
         {
-            "initialization_time": "2022-05-16T04:00",
+            "initialization_time": datetime.fromisoformat("2022-05-16T04:00"),
             "is_used": [False, False],
         },
         {
-            "initialization_time": "2022-05-16T07:00",
+            "initialization_time": datetime.fromisoformat("2022-05-16T07:00"),
             "is_used": [False, False],
         },
     ]

--- a/tests/test_unified_graphics.py
+++ b/tests/test_unified_graphics.py
@@ -164,7 +164,10 @@ def test_scalar_history(model, diag_parquet, client, test_dataset):
         diag_parquet(data)
 
     # Act
-    response = client.get("/diag/3DRTMA/WCOSS/CONUS/HRRR/REALTIME/ps/ges/?initialization_time=2022-05-16T04:00")
+    response = client.get(
+        "/diag/3DRTMA/WCOSS/CONUS/HRRR/REALTIME/ps/ges/"
+        "?initialization_time=2022-05-16T04:00"
+    )
 
     # Assert
     assert response.json == [
@@ -210,7 +213,10 @@ def test_scalar_history_unused(model, diag_parquet, client, test_dataset):
         diag_parquet(data)
 
     # Act
-    response = client.get("/diag/3DRTMA/WCOSS/CONUS/HRRR/REALTIME/ps/ges/?initialization_time=2022-05-16T07:00")
+    response = client.get(
+        "/diag/3DRTMA/WCOSS/CONUS/HRRR/REALTIME/ps/ges/"
+        "?initialization_time=2022-05-16T07:00"
+    )
 
     # Assert
     assert response.json == [
@@ -260,7 +266,10 @@ def test_scalar_history_empty(model, diag_parquet, test_dataset, client):
         diag_parquet(data)
 
     # Act
-    response = client.get("/diag/3DRTMA/WCOSS/CONUS/HRRR/REALTIME/ps/ges/?initialization_time=2022-05-16T07:00")
+    response = client.get(
+        "/diag/3DRTMA/WCOSS/CONUS/HRRR/REALTIME/ps/ges/"
+        "?initialization_time=2022-05-16T07:00"
+    )
 
     # Assert
     assert response.json == []

--- a/tests/test_unified_graphics.py
+++ b/tests/test_unified_graphics.py
@@ -163,7 +163,7 @@ def test_scalar_history(model, diag_parquet, client, test_dataset):
         diag_parquet(data)
 
     # Act
-    response = client.get("/diag/3DRTMA/WCOSS/CONUS/HRRR/REALTIME/ps/ges/")
+    response = client.get("/diag/3DRTMA/WCOSS/CONUS/HRRR/REALTIME/ps/ges/?initialization_time=2022-05-16T04:00")
 
     # Assert
     assert response.json == [
@@ -176,16 +176,6 @@ def test_scalar_history(model, diag_parquet, client, test_dataset):
             "max": 10.0,
             "mean": 7.5,
             "count": 2.0,
-        },
-        {
-            "initialization_time": "2022-05-16T07:00",
-            "min": -8.0,
-            "25%": -6.0,
-            "50%": -4.0,
-            "75%": -2.0,
-            "max": 0.0,
-            "mean": -4.0,
-            "count": 3.0,
         },
     ]
 
@@ -219,7 +209,7 @@ def test_scalar_history_unused(model, diag_parquet, client, test_dataset):
         diag_parquet(data)
 
     # Act
-    response = client.get("/diag/3DRTMA/WCOSS/CONUS/HRRR/REALTIME/ps/ges/")
+    response = client.get("/diag/3DRTMA/WCOSS/CONUS/HRRR/REALTIME/ps/ges/?initialization_time=2022-05-16T07:00")
 
     # Assert
     assert response.json == [
@@ -269,7 +259,7 @@ def test_scalar_history_empty(model, diag_parquet, test_dataset, client):
         diag_parquet(data)
 
     # Act
-    response = client.get("/diag/3DRTMA/WCOSS/CONUS/HRRR/REALTIME/ps/ges/")
+    response = client.get("/diag/3DRTMA/WCOSS/CONUS/HRRR/REALTIME/ps/ges/?initialization_time=2022-05-16T07:00")
 
     # Assert
     assert response.json == []


### PR DESCRIPTION
Limit the amount of data read in for the historical data to just two weeks prior to the initialization time. This should reduce memory usage in production and allow the application to continue working, solving #443 (I hope).

In future, we may make this range configurable by users, instead of hard-coding a two week limit.