### PR TITLE
Use os.path.join in diag.diag_observations

### DIFF
--- a/src/unified_graphics/diag.py
+++ b/src/unified_graphics/diag.py
@@ -118,7 +118,7 @@ def diag_observations(
         parquet_filters.append(("is_used", "=", is_used))
 
     df = pd.read_parquet(
-        os.path.join((uri, model_config, variable)),
+        os.path.join(uri, model_config, variable),
         columns=[
             "obs_minus_forecast_adjusted",
             "obs_minus_forecast_unadjusted",

--- a/src/unified_graphics/diag.py
+++ b/src/unified_graphics/diag.py
@@ -118,7 +118,7 @@ def diag_observations(
         parquet_filters.append(("is_used", "=", is_used))
 
     df = pd.read_parquet(
-        "/".join((uri, model_config, variable)),
+        os.path.join((uri, model_config, variable)),
         columns=[
             "obs_minus_forecast_adjusted",
             "obs_minus_forecast_unadjusted",


### PR DESCRIPTION
Replace "/".join() with os.path.join() to build the path for the Parquet file in S3. Unlike a file system, it seems that having a double "//" in the path is breaking the S3 access in Pandas.